### PR TITLE
Floating point operations

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -217,18 +217,20 @@ impl Hex {
         Self::new(x_r as i32, y_r as i32)
     }
 
+    #[allow(clippy::cast_precision_loss)]
+    #[inline]
     #[must_use]
     /// Divides `self` by `rhs`, rounding up to the closest `Hex`
     pub fn rounded_div(self, rhs: f32) -> Self {
-        let v: Vec2 = self.into();
-        Self::from(v / rhs)
+        Self::round((self.x as f32 / rhs, self.y as f32 / rhs))
     }
 
+    #[allow(clippy::cast_precision_loss)]
+    #[inline]
     #[must_use]
     /// Multiplies `self` by `rhs`, rounding up to the closest `Hex`
     pub fn rounded_mul(self, rhs: f32) -> Self {
-        let v: Vec2 = self.into();
-        Self::from(v * rhs)
+        Self::round((self.x as f32 * rhs, self.y as f32 * rhs))
     }
 
     #[inline]
@@ -569,6 +571,7 @@ impl Hex {
 impl Add<Self> for Hex {
     type Output = Self;
 
+    #[inline]
     fn add(self, rhs: Self) -> Self::Output {
         self.const_add(rhs)
     }
@@ -577,6 +580,7 @@ impl Add<Self> for Hex {
 impl Add<i32> for Hex {
     type Output = Self;
 
+    #[inline]
     fn add(self, rhs: i32) -> Self::Output {
         Self {
             x: self.x + rhs,
@@ -586,12 +590,14 @@ impl Add<i32> for Hex {
 }
 
 impl AddAssign for Hex {
+    #[inline]
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
     }
 }
 
 impl AddAssign<i32> for Hex {
+    #[inline]
     fn add_assign(&mut self, rhs: i32) {
         *self = *self + rhs;
     }
@@ -600,6 +606,7 @@ impl AddAssign<i32> for Hex {
 impl Sub<Self> for Hex {
     type Output = Self;
 
+    #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
         self.const_sub(rhs)
     }
@@ -608,6 +615,7 @@ impl Sub<Self> for Hex {
 impl Sub<i32> for Hex {
     type Output = Self;
 
+    #[inline]
     fn sub(self, rhs: i32) -> Self::Output {
         Self {
             x: self.x - rhs,
@@ -617,12 +625,14 @@ impl Sub<i32> for Hex {
 }
 
 impl SubAssign for Hex {
+    #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
 impl SubAssign<i32> for Hex {
+    #[inline]
     fn sub_assign(&mut self, rhs: i32) {
         *self = *self - rhs;
     }
@@ -631,6 +641,7 @@ impl SubAssign<i32> for Hex {
 impl Mul<Self> for Hex {
     type Output = Self;
 
+    #[inline]
     fn mul(self, rhs: Self) -> Self::Output {
         Self {
             x: self.x * rhs.x,
@@ -642,6 +653,7 @@ impl Mul<Self> for Hex {
 impl Mul<i32> for Hex {
     type Output = Self;
 
+    #[inline]
     fn mul(self, rhs: i32) -> Self::Output {
         Self {
             x: self.x * rhs,
@@ -653,24 +665,28 @@ impl Mul<i32> for Hex {
 impl Mul<f32> for Hex {
     type Output = Self;
 
+    #[inline]
     fn mul(self, rhs: f32) -> Self::Output {
         self.rounded_mul(rhs)
     }
 }
 
 impl MulAssign for Hex {
+    #[inline]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
     }
 }
 
 impl MulAssign<i32> for Hex {
+    #[inline]
     fn mul_assign(&mut self, rhs: i32) {
         *self = *self * rhs;
     }
 }
 
 impl MulAssign<f32> for Hex {
+    #[inline]
     fn mul_assign(&mut self, rhs: f32) {
         *self = *self * rhs;
     }
@@ -679,6 +695,7 @@ impl MulAssign<f32> for Hex {
 impl Div<Self> for Hex {
     type Output = Self;
 
+    #[inline]
     fn div(self, rhs: Self) -> Self::Output {
         Self {
             x: self.x / rhs.x,
@@ -690,6 +707,7 @@ impl Div<Self> for Hex {
 impl Div<i32> for Hex {
     type Output = Self;
 
+    #[inline]
     fn div(self, rhs: i32) -> Self::Output {
         Self {
             x: self.x / rhs,
@@ -701,24 +719,28 @@ impl Div<i32> for Hex {
 impl Div<f32> for Hex {
     type Output = Self;
 
+    #[inline]
     fn div(self, rhs: f32) -> Self::Output {
         self.rounded_div(rhs)
     }
 }
 
 impl DivAssign for Hex {
+    #[inline]
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs;
     }
 }
 
 impl DivAssign<i32> for Hex {
+    #[inline]
     fn div_assign(&mut self, rhs: i32) {
         *self = *self / rhs;
     }
 }
 
 impl DivAssign<f32> for Hex {
+    #[inline]
     fn div_assign(&mut self, rhs: f32) {
         *self = *self / rhs;
     }
@@ -727,6 +749,7 @@ impl DivAssign<f32> for Hex {
 impl Rem<Self> for Hex {
     type Output = Self;
 
+    #[inline]
     fn rem(self, rhs: Self) -> Self::Output {
         Self {
             x: self.x % rhs.x,
@@ -738,6 +761,7 @@ impl Rem<Self> for Hex {
 impl Rem<i32> for Hex {
     type Output = Self;
 
+    #[inline]
     fn rem(self, rhs: i32) -> Self::Output {
         Self {
             x: self.x % rhs,
@@ -747,12 +771,14 @@ impl Rem<i32> for Hex {
 }
 
 impl RemAssign for Hex {
+    #[inline]
     fn rem_assign(&mut self, rhs: Self) {
         *self = *self % rhs;
     }
 }
 
 impl RemAssign<i32> for Hex {
+    #[inline]
     fn rem_assign(&mut self, rhs: i32) {
         *self = *self % rhs;
     }
@@ -761,36 +787,42 @@ impl RemAssign<i32> for Hex {
 impl Neg for Hex {
     type Output = Self;
 
+    #[inline]
     fn neg(self) -> Self::Output {
         self.const_neg()
     }
 }
 
 impl From<(i32, i32)> for Hex {
+    #[inline]
     fn from((x, y): (i32, i32)) -> Self {
         Self { x, y }
     }
 }
 
 impl From<[i32; 2]> for Hex {
+    #[inline]
     fn from([x, y]: [i32; 2]) -> Self {
         Self { x, y }
     }
 }
 
 impl From<(f32, f32)> for Hex {
+    #[inline]
     fn from(v: (f32, f32)) -> Self {
         Self::round(v)
     }
 }
 
 impl From<[f32; 2]> for Hex {
+    #[inline]
     fn from([x, y]: [f32; 2]) -> Self {
         Self::round((x, y))
     }
 }
 
 impl From<Hex> for IVec2 {
+    #[inline]
     fn from(hex: Hex) -> Self {
         Self::new(hex.x, hex.y)
     }
@@ -798,24 +830,28 @@ impl From<Hex> for IVec2 {
 
 impl From<Hex> for Vec2 {
     #[allow(clippy::cast_precision_loss)]
+    #[inline]
     fn from(value: Hex) -> Self {
         Self::new(value.x as f32, value.y as f32)
     }
 }
 
 impl From<Vec2> for Hex {
+    #[inline]
     fn from(value: Vec2) -> Self {
         Self::round((value.x, value.y))
     }
 }
 
 impl From<Hex> for IVec3 {
+    #[inline]
     fn from(hex: Hex) -> Self {
         Self::new(hex.x, hex.y, hex.z())
     }
 }
 
 impl From<IVec2> for Hex {
+    #[inline]
     fn from(v: IVec2) -> Self {
         Self::new(v.x, v.y)
     }


### PR DESCRIPTION
> Closes #9 

In addition to the improvements of #12 (Implementing the `%` operator) this PR adds the following:

- `Hex::rounded_div` to perform `f32` division, correctly rounded to the closest `Hex`
- `Hex::rounded_mul` to perform `f32` multiplication, correctly rounded to the closest `Hex`
- The matching `Div<f32>` and `Mul<f32>` implementations
- `From<Vec2>` implementation, using the rounding method
- `From<(f32, f32)>` implementation, using the rounding method
- `From<[f32, f32]>` implementation, using the rounding method

Therefore this PR makes the following proposition to adress #9 :

- `Hex` divided by an integer value will perform a naive, unrounded, "classic" integer division 
- `Hex` divided by a floating point value will perform a rounded division, giving the expected result.