### PR TITLE
Pub use conversions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,9 @@ mod orientation;
 
 /// Used glam types reexport
 pub use glam::{IVec2, Vec2};
-pub use {bounds::*, direction::*, hex::*, hex_map::*, layout::*, mesh::*, orientation::*};
+pub use {
+    bounds::*, conversions::*, direction::*, hex::*, hex_map::*, layout::*, mesh::*, orientation::*,
+};
 
 /// Map shapes generation functions
 pub mod shapes {


### PR DESCRIPTION
I noticed that [`Hex::to_offset_coordinates`](https://docs.rs/hexx/latest/hexx/struct.Hex.html#method.from_offset_coordinates) could not be used because the `OffsetHexMode` was private. This commit fixes that.

Your library is really nice to use, I was only missing this function :)