### PR TITLE
Fixed empty line to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+* Fixed `conversion` module was private (#42)
+* Fixed `Hex::line_to` returning `(0, 0)` when both ends are identical (#43)
+
 ## 0.4.1
 
 ### Fix

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -719,9 +719,10 @@ impl Hex {
     /// assert_eq!(line.len(), 6);
     /// ````
     pub fn line_to(self, other: Self) -> impl Iterator<Item = Self> {
-        let distance = self.distance_to(other).max(1);
+        let distance = self.distance_to(other);
+        let dist = distance.max(1) as f32;
         let [a, b]: [Vec2; 2] = [self.as_vec2(), other.as_vec2()];
-        (0..=distance).map(move |step| a.lerp(b, step as f32 / distance as f32).into())
+        (0..=distance).map(move |step| a.lerp(b, step as f32 / dist).into())
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -719,7 +719,7 @@ impl Hex {
     /// assert_eq!(line.len(), 6);
     /// ````
     pub fn line_to(self, other: Self) -> impl Iterator<Item = Self> {
-        let distance = self.distance_to(other);
+        let distance = self.distance_to(other).max(1);
         let [a, b]: [Vec2; 2] = [self.as_vec2(), other.as_vec2()];
         (0..=distance).map(move |step| a.lerp(b, step as f32 / distance as f32).into())
     }

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -341,7 +341,7 @@ fn line_to() {
 fn empty_line_to() {
     let start = Hex::new(3, -7);
     let line: Vec<_> = start.line_to(start).collect();
-    assert_eq!(line, vec![start, start]);
+    assert_eq!(line, vec![start]);
 }
 
 #[test]

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -338,6 +338,13 @@ fn line_to() {
 }
 
 #[test]
+fn empty_line_to() {
+    let start = Hex::new(3, -7);
+    let line: Vec<_> = start.line_to(start).collect();
+    assert_eq!(line, vec![start, start]);
+}
+
+#[test]
 fn directions_to() {
     let a = Hex::new(0, 0);
     let b = Hex::new(5, 5);


### PR DESCRIPTION
> Closes #43 

Fixes empty `line_to` implementation. With this fix the returned line will always contain at least both `start` and `end` coordinates.