### PR TITLE
Hex cubic array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # CHANGELOG
 
+## Unreleased
+
+* Deprecated `Hex::to_array3` in favor of `Hex::to_cubic_array`
+
 ## 0.4.2
 
 * Fixed `conversion` module was private (#42)
 * Fixed `Hex::line_to` returning `(0, 0)` when both ends are identical (#43)
-* Deprecated `Hex::to_array3` in favor of `Hex::to_cubic_array`
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed `conversion` module was private (#42)
 * Fixed `Hex::line_to` returning `(0, 0)` when both ends are identical (#43)
+* Deprecated `Hex::to_array3` in favor of `Hex::to_cubic_array`
 
 ## 0.4.1
 

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -243,7 +243,7 @@ impl Hex {
 
     #[inline]
     #[must_use]
-    #[deprecated(since = "0.4.2", note = "Prefer Hex::to_cubic_array")]
+    #[deprecated(since = "0.5.0", note = "Prefer Hex::to_cubic_array")]
     /// Converts `self` to cubic coordinates an array as `[x, y, z]`
     pub const fn to_array3(self) -> [i32; 3] {
         self.to_cubic_array()
@@ -573,7 +573,7 @@ impl Hex {
     #[must_use]
     /// Find in which [`DiagonalDirection`] wedge `rhs` is relative to `self`
     pub fn diagonal_to(self, rhs: Self) -> DiagonalDirection {
-        let [x, y, z] = (rhs - self).to_array3();
+        let [x, y, z] = (rhs - self).to_cubic_array();
         let [xa, ya, za] = [x.abs(), y.abs(), z.abs()];
         let (v, dir) = match xa.max(ya).max(za) {
             v if v == xa => (x, DiagonalDirection::Right),
@@ -591,7 +591,7 @@ impl Hex {
     #[must_use]
     /// Find in which [`Direction`] wedge `rhs` is relative to `self`
     pub fn direction_to(self, rhs: Self) -> Direction {
-        let [x, y, z] = (rhs - self).to_array3();
+        let [x, y, z] = (rhs - self).to_cubic_array();
         let [x, y, z] = [y - x, z - y, x - z];
         let [xa, ya, za] = [x.abs(), y.abs(), z.abs()];
         let (v, dir) = match xa.max(ya).max(za) {

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -225,7 +225,7 @@ impl Hex {
 
     #[inline]
     #[must_use]
-    /// Converts `self` to an array as `[x, y, z]`
+    /// Converts `self` to cubic coordinates an array as `[x, y, z]`
     ///
     /// # Example
     ///
@@ -237,8 +237,16 @@ impl Hex {
     /// assert_eq!(y, 5);
     /// assert_eq!(z, -3-5);
     /// ```
-    pub const fn to_array3(self) -> [i32; 3] {
+    pub const fn to_cubic_array(self) -> [i32; 3] {
         [self.x, self.y, self.z()]
+    }
+
+    #[inline]
+    #[must_use]
+    #[deprecated(since = "0.4.2", note = "Prefer Hex::to_cubic_array")]
+    /// Converts `self` to cubic coordinates an array as `[x, y, z]`
+    pub const fn to_array3(self) -> [i32; 3] {
+        self.to_cubic_array()
     }
 
     // Creates a [`Hex`] from the first 2 values in `slice`.
@@ -279,6 +287,7 @@ impl Hex {
 
     #[must_use]
     #[inline]
+    #[doc(alias = "as_cubic")]
     /// Converts `self` to an [`IVec3`] using cubic coordinates.
     /// This operation is a direct mapping of coordinates.
     /// To convert hex coordinates to world space use [`HexLayout`]


### PR DESCRIPTION
> Closes #41 

# Work done

- `Hex` already has a `as_ivec3` method, but I added a doc alias
- Renamed `Hex::to_array3` to `Hex::to_cubic_array` and deprecated the previous version