### PR TITLE
ExactSizeIterator

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,4 +67,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: rustdoc
-        run: cargo rustdoc --all-features
+        run: cargo rustdoc --all-features -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### FixedSizeIterator
+
 * Deprecated `Hex::to_array3` in favor of `Hex::to_cubic_array`
 * `Hex::range` now returns a `FixedSizeIterator` instead of a simple `Iterator`
 * `Hex::line_to` now returns a `FixedSizeIterator` instead of a simple `Iterator`
@@ -10,6 +12,10 @@
 
 * (**BREAKING**) `Hex::ring_edge` now returns a `FixedSizeIterator` instead of a `Vec`
 * (**BREAKING**) `Hex::custom_ring_edge` now returns a `FixedSizeIterator` instead of a `Vec`
+
+### Miscellaneous
+
+* Added `Hex::wedge_count` to count the amount of coordinate in a wedge
 
 ## 0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@
 * `Hex::line_to` now returns a `ExactSizeIterator` instead of a simple `Iterator`
 * `Hex::wedge_to` now returns a `ExactSizeIterator` instead of a simple `Iterator`
 * `Hex::custom_wedge_to` now returns a `ExactSizeIterator` instead of a simple `Iterator`
-* `shapes::hexagon` now returns a `ExactSizeIterator` instead of a simple `Iterator`
 * `HexBounds::all_coords` now returns a `ExactSizeIterator` instead of a simple `Iterator`
+* `shapes::hexagon` now returns a `ExactSizeIterator` instead of a simple `Iterator`
+* `shapes::parallelogram` now returns a `ExactSizeIterator` instead of a simple `Iterator`
+* `shapes::triangle` now returns a `ExactSizeIterator` instead of a simple `Iterator`
+* `shapes::pointy_rectangle` now returns a `ExactSizeIterator` instead of a simple `Iterator`
+* `shapes::flat_rectangle` now returns a `ExactSizeIterator` instead of a simple `Iterator`
 
 * (**BREAKING**) `Hex::ring_edge` now returns a `ExactSizeIterator` instead of a `Vec`
 * (**BREAKING**) `Hex::custom_ring_edge` now returns a `ExactSizeIterator` instead of a `Vec`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 * Deprecated `Hex::to_array3` in favor of `Hex::to_cubic_array`
+* `Hex::range` now returns a `FixedSizeIterator` instead of a simple `Iterator`
+* `Hex::line_to` now returns a `FixedSizeIterator` instead of a simple `Iterator`
+* `shapes::hexagon` now returns a `FixedSizeIterator` instead of a simple `Iterator`
+* `HexBounds::all_coords` now returns a `FixedSizeIterator` instead of a simple `Iterator`
 
 ## 0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Miscellaneous
 
 * Deprecated `Hex::to_array3` in favor of `Hex::to_cubic_array`
+* Made most modules public but kept the wildcard exports at the crate root
 
 ## 0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 * (**BREAKING**) `Hex::ring_edge` now returns a `ExactSizeIterator` instead of a `Vec`
 * (**BREAKING**) `Hex::custom_ring_edge` now returns a `ExactSizeIterator` instead of a `Vec`
+* (**BREAKING**) `Hex::custom_ring_edges` now returns an `Iterator` with an `ExactSizeIterator` item instead of a `Vec`
+* (**BREAKING**) `Hex::ring_edges` now returns an `Iterator` with an `ExactSizeIterator` item instead of a `Vec`
 
 ### Additions 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * `shapes::hexagon` now returns a `FixedSizeIterator` instead of a simple `Iterator`
 * `HexBounds::all_coords` now returns a `FixedSizeIterator` instead of a simple `Iterator`
 
+* (**BREAKING**) `Hex::ring_edge` now returns a `FixedSizeIterator` instead of a `Vec`
+* (**BREAKING**) `Hex::custom_ring_edge` now returns a `FixedSizeIterator` instead of a `Vec`
+
 ## 0.4.2
 
 * Fixed `conversion` module was private (#42)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,27 @@
 
 ## Unreleased
 
-### FixedSizeIterator
+### ExactSizeIterator
 
-* Deprecated `Hex::to_array3` in favor of `Hex::to_cubic_array`
-* `Hex::range` now returns a `FixedSizeIterator` instead of a simple `Iterator`
-* `Hex::line_to` now returns a `FixedSizeIterator` instead of a simple `Iterator`
-* `shapes::hexagon` now returns a `FixedSizeIterator` instead of a simple `Iterator`
-* `HexBounds::all_coords` now returns a `FixedSizeIterator` instead of a simple `Iterator`
+* `Hex::range` now returns a `ExactSizeIterator` instead of a simple `Iterator`
+* `Hex::line_to` now returns a `ExactSizeIterator` instead of a simple `Iterator`
+* `Hex::wedge_to` now returns a `ExactSizeIterator` instead of a simple `Iterator`
+* `Hex::custom_wedge_to` now returns a `ExactSizeIterator` instead of a simple `Iterator`
+* `shapes::hexagon` now returns a `ExactSizeIterator` instead of a simple `Iterator`
+* `HexBounds::all_coords` now returns a `ExactSizeIterator` instead of a simple `Iterator`
 
-* (**BREAKING**) `Hex::ring_edge` now returns a `FixedSizeIterator` instead of a `Vec`
-* (**BREAKING**) `Hex::custom_ring_edge` now returns a `FixedSizeIterator` instead of a `Vec`
+* (**BREAKING**) `Hex::ring_edge` now returns a `ExactSizeIterator` instead of a `Vec`
+* (**BREAKING**) `Hex::custom_ring_edge` now returns a `ExactSizeIterator` instead of a `Vec`
+
+### Additions 
+
+* Added `Hex::wedge_count` to count the amount of coordinate in a wedge
+* Added `Hex::full_wedge` which returns an `ExactSizeIterator`
+* Added `Hex::custom_full_wedge` which returns an `ExactSizeIterator`
 
 ### Miscellaneous
 
-* Added `Hex::wedge_count` to count the amount of coordinate in a wedge
+* Deprecated `Hex::to_array3` in favor of `Hex::to_cubic_array`
 
 ## 0.4.2
 

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -36,14 +36,17 @@ impl HexBounds {
 
     #[must_use]
     #[inline]
+    #[doc(alias = "coords_count")]
+    #[doc(alias = "len")]
     /// Returns the number of hexagons in bounds
     pub const fn hex_count(&self) -> usize {
         Hex::range_count(self.radius)
     }
 
     #[doc(alias = "all_items")]
+    #[must_use]
     /// Returns an iterator with all the coordinates in bounds
-    pub fn all_coords(&self) -> impl Iterator<Item = Hex> {
+    pub fn all_coords(&self) -> impl ExactSizeIterator<Item = Hex> {
         self.center.range(self.radius)
     }
 

--- a/src/direction/mod.rs
+++ b/src/direction/mod.rs
@@ -1,6 +1,10 @@
 /// [`Hex`] diagonal directions
+///
+/// [`Hex`]: crate::Hex
 mod diagonal_direction;
 /// [`Hex`] neighbor directions
+///
+/// [`Hex`]: crate::Hex
 mod hex_direction;
 /// Trait implementations
 mod impls;

--- a/src/hex/iter.rs
+++ b/src/hex/iter.rs
@@ -66,3 +66,30 @@ impl<I: Iterator<Item = Hex>> HexIterExt for I {
         self.collect()
     }
 }
+
+/// Private container for a [`Hex`] [`Iterator`] of known size
+#[derive(Debug, Clone)]
+pub struct ExactSizeHexIterator<I> {
+    /// The inner iterator
+    pub iter: I,
+    /// The remaining iterator elements count
+    pub count: usize,
+}
+
+impl<I> Iterator for ExactSizeHexIterator<I>
+where
+    I: Iterator<Item = Hex>,
+{
+    type Item = Hex;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.count = self.count.saturating_sub(1);
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.count, Some(self.count))
+    }
+}
+
+impl<I> ExactSizeIterator for ExactSizeHexIterator<I> where I: Iterator<Item = Hex> {}

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -3,7 +3,7 @@ mod convert;
 /// Traits implementations
 mod impls;
 /// Iterator tools module
-mod iter;
+pub(crate) mod iter;
 /// Hex ring utils
 mod rings;
 #[cfg(test)]

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -3,17 +3,17 @@ mod convert;
 /// Traits implementations
 mod impls;
 /// Iterator tools module
-pub(crate) mod iter;
+mod iter;
 /// Hex ring utils
 mod rings;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use iter::ExactSizeHexIterator;
 pub use iter::HexIterExt;
 
 use crate::{DiagonalDirection, Direction};
 use glam::{IVec2, IVec3, Vec2};
-use iter::ExactSizeHexIterator;
 use itertools::Itertools;
 use std::cmp::{max, min};
 

--- a/src/hex/rings.rs
+++ b/src/hex/rings.rs
@@ -214,6 +214,22 @@ impl Hex {
         self.custom_wedge(0..=range, direction, clockwise)
     }
 
+    /// Counts how many coordinates there are in a wedge of given `range`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let hex = Hex::new(3, -6);
+    /// let wedge: Vec<Hex> = hex.wedge(0..=13, DiagonalDirection::Right).collect();
+    /// assert_eq!(wedge.len(), Hex::wedge_count(13) as usize);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn wedge_count(range: u32) -> u32 {
+        range * (range + 3) / 2 + 1
+    }
+
     /// Retrieves all successive [`Hex`] ring edges around `self` in a given `range` and
     /// `direction`.
     /// The returned edges coordinates are sorted counter clockwise around `self`.

--- a/src/hex/rings.rs
+++ b/src/hex/rings.rs
@@ -70,7 +70,7 @@ impl Hex {
     }
 
     /// Retrieves `range` [`Hex`] rings around `self` in a given `range`.
-    /// The returned coordinates start from [`start_dir`] and loop around `self` counter clockwise
+    /// The returned coordinates start from `start_dir` and loop around `self` counter clockwise
     /// unless `clockwise` is set to true.
     ///
     /// If you only need the coordinates see [`Self::spiral_range`] or [`Self::rings`].
@@ -299,7 +299,7 @@ impl Hex {
     /// Retrieves all successive [`Hex`] half ring edges around `self` in a given `range` and
     /// `direction`.
     ///
-    /// See also [`Self::wedge_dir_to`] and [`Self::wedge`]
+    /// See also [`Self::corner_wedge_to`] and [`Self::wedge`]
     pub fn corner_wedge(
         self,
         range: impl Iterator<Item = u32> + Clone,
@@ -313,7 +313,7 @@ impl Hex {
 
     /// Retrieves all successive [`Hex`] half ring edges from `self` to `rhs`
     ///
-    /// See also [`Self::wedge_dir`] and [`Self::wedge_to`]
+    /// See also [`Self::corner_wedge_to`] and [`Self::wedge_to`]
     pub fn corner_wedge_to(self, rhs: Self) -> impl Iterator<Item = Self> {
         let range = self.unsigned_distance_to(rhs);
         self.corner_wedge(0..=range, self.direction_to(rhs))
@@ -326,7 +326,7 @@ impl Hex {
     /// The returned edges coordinates are sorted counter clockwise around `self` unless
     /// `clockwise` is set to `true`.
     ///
-    /// See also [`Self::custom_cached_ring_edges`]
+    /// See also [`Self::cached_ring_edges`]
     /// If you only need the coordinates see [`Self::ring_edges`] or [`Self::wedge`].
     ///
     /// # Usage
@@ -366,7 +366,7 @@ impl Hex {
     /// `direction` as an array of edges.
     /// The returned edges coordinates are sorted counter clockwise around `self`.
     ///
-    /// See also [`Self::custom_cached_ring_edges`]
+    /// See also [`Self::cached_custom_ring_edges`]
     /// If you only need the coordinates see [`Self::ring_edges`] or [`Self::wedge`].
     ///
     /// # Usage
@@ -402,7 +402,7 @@ impl Hex {
     /// rings.
     /// The returned rings start from [`Direction::TopRight`] and loop around `self` counter clockwise.
     ///
-    /// See also [`Self::custom_cached_rings`]
+    /// See also [`Self::cached_custom_rings`]
     /// If you only need the coordinates see [`Self::range`] or [`Self::spiral_range`].
     ///
     /// # Usage

--- a/src/hex/rings.rs
+++ b/src/hex/rings.rs
@@ -217,10 +217,7 @@ impl Hex {
     ) -> impl ExactSizeIterator<Item = Self> {
         let range = self.unsigned_distance_to(rhs);
         let direction = self.diagonal_to(rhs);
-        ExactSizeHexIterator {
-            iter: self.custom_wedge(0..=range, direction, clockwise),
-            count: Self::wedge_count(range) as usize,
-        }
+        self.custom_full_wedge(range, direction, clockwise)
     }
 
     /// Retrieves all successive [`Hex`] ring edges around `self` in a given `range` and `direction`
@@ -280,8 +277,7 @@ impl Hex {
     }
 
     /// Retrieves all successive [`Hex`] ring edges around `self` in a given `range` and `direction`
-    /// The returned edges coordinates are sorted counter clockwise around `self` unless
-    /// `clockwise` is set to `true`.
+    /// The returned edges coordinates are sorted counter clockwise around `self`.
     ///
     /// See also [`Self::custom_full_wedge`] and [`Self::wedge`]
     #[must_use]
@@ -290,10 +286,7 @@ impl Hex {
         range: u32,
         direction: DiagonalDirection,
     ) -> impl ExactSizeIterator<Item = Self> {
-        ExactSizeHexIterator {
-            iter: self.wedge(0..=range, direction),
-            count: Self::wedge_count(range) as usize,
-        }
+        self.custom_full_wedge(range, direction, false)
     }
 
     /// Retrieves all successive [`Hex`] half ring edges around `self` in a given `range` and

--- a/src/hex/rings.rs
+++ b/src/hex/rings.rs
@@ -158,8 +158,8 @@ impl Hex {
         self,
         ranges: impl Iterator<Item = u32>,
         direction: DiagonalDirection,
-    ) -> impl Iterator<Item = Vec<Self>> {
-        ranges.map(move |r| self.ring_edge(r, direction).collect())
+    ) -> impl Iterator<Item = impl ExactSizeIterator<Item = Self>> {
+        ranges.map(move |r| self.ring_edge(r, direction))
     }
 
     /// Retrieves all successive [`Hex`] ring edges around `self` in given `ranges` and
@@ -182,8 +182,8 @@ impl Hex {
         ranges: impl Iterator<Item = u32>,
         direction: DiagonalDirection,
         clockwise: bool,
-    ) -> impl Iterator<Item = Vec<Self>> {
-        ranges.map(move |r| self.custom_ring_edge(r, direction, clockwise).collect())
+    ) -> impl Iterator<Item = impl ExactSizeIterator<Item = Self>> {
+        ranges.map(move |r| self.custom_ring_edge(r, direction, clockwise))
     }
 
     /// Retrieves all successive [`Hex`] ring edges around `self` in given `ranges` and

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -458,9 +458,7 @@ fn custom_ring() {
 fn ring_edge() {
     let hex = Hex::new(-189, 35);
     let edge = hex.ring_edge(48, DiagonalDirection::TopRight);
-    let len = edge.len();
-    let edge: Vec<_> = edge.collect();
-    assert_eq!(edge.len(), len);
+    assert_eq!(edge.len(), edge.count());
     // empty
     let edge = hex.ring_edge(0, DiagonalDirection::TopRight);
     let len = edge.len();
@@ -473,6 +471,19 @@ fn ring_edge() {
     let edge: Vec<_> = edge.collect();
     assert_eq!(edge.len(), len);
     assert_eq!(edge.len(), 2);
+}
+
+#[test]
+#[allow(clippy::cast_possible_truncation)]
+fn wedge() {
+    let hex = Hex::new(98, -123);
+    for dir in DiagonalDirection::ALL_DIRECTIONS {
+        for range in 0..=30 {
+            let wedge: Vec<_> = hex.wedge(0..=range, dir).collect();
+            assert_eq!(wedge.len() as u32, range * (range + 3) / 2 + 1);
+            assert_eq!(wedge.len() as u32, Hex::wedge_count(range));
+        }
+    }
 }
 
 #[test]

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -307,8 +307,12 @@ fn lerp() {
 fn line_to() {
     let a = Hex::new(0, 0);
     let b = Hex::new(5, 0);
+    let line = a.line_to(b);
+    let len = line.len();
+    let line: Vec<_> = line.collect();
+    assert_eq!(line.len(), len);
     assert_eq!(
-        a.line_to(b).collect::<Vec<_>>(),
+        line,
         vec![
             a,
             Hex::new(1, 0),
@@ -319,8 +323,12 @@ fn line_to() {
         ]
     );
     let b = Hex::new(5, 5);
+    let line = a.line_to(b);
+    let len = line.len();
+    let line: Vec<_> = line.collect();
+    assert_eq!(line.len(), len);
     assert_eq!(
-        a.line_to(b).collect::<Vec<_>>(),
+        line,
         vec![
             a,
             Hex::new(0, 1),
@@ -340,8 +348,9 @@ fn line_to() {
 #[test]
 fn empty_line_to() {
     let start = Hex::new(3, -7);
-    let line: Vec<_> = start.line_to(start).collect();
-    assert_eq!(line, vec![start]);
+    let line = start.line_to(start);
+    assert_eq!(line.len(), 1);
+    assert_eq!(line.collect::<Vec<_>>(), vec![start]);
 }
 
 #[test]
@@ -371,6 +380,22 @@ fn range_count() {
     assert_eq!(Hex::range_count(1), 7);
     assert_eq!(Hex::range_count(10), 331);
     assert_eq!(Hex::range_count(15), 721);
+}
+
+#[test]
+fn range() {
+    let hex = Hex::new(13, -54);
+    let mut range = hex.range(16);
+    assert_eq!(range.len(), Hex::range_count(16));
+    assert_eq!(range.size_hint(), (range.len(), Some(range.len())));
+    println!("{:#?}", range.size_hint());
+    let _ = range.next();
+    println!("{:#?}", range.size_hint());
+    assert_eq!(range.len(), Hex::range_count(16) - 1);
+    assert_eq!(range.size_hint(), (range.len(), Some(range.len())));
+    let _ = range.next();
+    assert_eq!(range.len(), Hex::range_count(16) - 2);
+    assert_eq!(range.size_hint(), (range.len(), Some(range.len())));
 }
 
 #[test]

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -482,6 +482,8 @@ fn wedge() {
             let wedge: Vec<_> = hex.wedge(0..=range, dir).collect();
             assert_eq!(wedge.len() as u32, range * (range + 3) / 2 + 1);
             assert_eq!(wedge.len() as u32, Hex::wedge_count(range));
+            let full_wedge = hex.full_wedge(range, dir);
+            assert_eq!(full_wedge.len(), wedge.len());
         }
     }
 }

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -455,6 +455,27 @@ fn custom_ring() {
 }
 
 #[test]
+fn ring_edge() {
+    let hex = Hex::new(-189, 35);
+    let edge = hex.ring_edge(48, DiagonalDirection::TopRight);
+    let len = edge.len();
+    let edge: Vec<_> = edge.collect();
+    assert_eq!(edge.len(), len);
+    // empty
+    let edge = hex.ring_edge(0, DiagonalDirection::TopRight);
+    let len = edge.len();
+    let edge: Vec<_> = edge.collect();
+    assert_eq!(edge.len(), len);
+    assert_eq!(edge, vec![hex]);
+    // len 1
+    let edge = hex.ring_edge(1, DiagonalDirection::TopRight);
+    let len = edge.len();
+    let edge: Vec<_> = edge.collect();
+    assert_eq!(edge.len(), len);
+    assert_eq!(edge.len(), 2);
+}
+
+#[test]
 fn spiral_range() {
     let expected: Vec<_> = Hex::ZERO.range(10).collect();
     let spiral: Vec<_> = Hex::ZERO.spiral_range(0..=10).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,19 +118,27 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::nursery, clippy::pedantic, clippy::cargo, missing_docs)]
 #![allow(clippy::default_trait_access, clippy::module_name_repetitions)]
-mod bounds;
-mod conversions;
-mod direction;
-mod hex;
-mod hex_map;
-mod layout;
-mod mesh;
-mod orientation;
+/// Hexagonal range bounds module
+pub mod bounds;
+/// Hexagonal coordinates conversion module
+pub mod conversions;
+/// Hexagonal directions module
+pub mod direction;
+/// Hexagonal coordinates module
+pub mod hex;
+/// Wraparound hex grid module
+pub mod hex_map;
+/// Hexagonal layout module
+pub mod layout;
+/// Mesh generation utils module
+pub mod mesh;
+/// Hexagon oritentation module
+pub mod orientation;
+/// Map shapes generation functions
+pub mod shapes;
 
 /// Used glam types reexport
 pub use glam::{IVec2, Vec2};
 pub use {
     bounds::*, conversions::*, direction::*, hex::*, hex_map::*, layout::*, mesh::*, orientation::*,
 };
-/// Map shapes generation functions
-pub mod shapes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,8 +152,9 @@ pub mod shapes {
         (0..=size).flat_map(move |x| (0..=(size - x)).map(move |y| Hex::new(x as i32, y as i32)))
     }
 
+    #[must_use]
     /// Generates an hexagonal layout around `center` with a custom `radius`.
-    pub fn hexagon(center: Hex, radius: u32) -> impl Iterator<Item = Hex> {
+    pub fn hexagon(center: Hex, radius: u32) -> impl ExactSizeIterator<Item = Hex> {
         center.range(radius)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,45 +132,5 @@ pub use glam::{IVec2, Vec2};
 pub use {
     bounds::*, conversions::*, direction::*, hex::*, hex_map::*, layout::*, mesh::*, orientation::*,
 };
-
 /// Map shapes generation functions
-pub mod shapes {
-    use super::Hex;
-
-    /// Generates a parallelogram layout from `min` to `max`
-    pub fn parallelogram(min: Hex, max: Hex) -> impl Iterator<Item = Hex> {
-        (min.x()..=max.x()).flat_map(move |x| (min.y()..=max.y()).map(move |y| Hex::new(x, y)))
-    }
-
-    /// Generates a triangle with a custom `size`
-    ///
-    /// # Note
-    ///
-    /// To offset the map, apply the offset to each `Item` of the returned iterator
-    #[allow(clippy::cast_possible_wrap)]
-    pub fn triangle(size: u32) -> impl Iterator<Item = Hex> {
-        (0..=size).flat_map(move |x| (0..=(size - x)).map(move |y| Hex::new(x as i32, y as i32)))
-    }
-
-    #[must_use]
-    /// Generates an hexagonal layout around `center` with a custom `radius`.
-    pub fn hexagon(center: Hex, radius: u32) -> impl ExactSizeIterator<Item = Hex> {
-        center.range(radius)
-    }
-
-    /// Generates a rectangle with the given bounds for "pointy topped" hexagons
-    pub fn pointy_rectangle([left, right, top, bottom]: [i32; 4]) -> impl Iterator<Item = Hex> {
-        (top..=bottom).flat_map(move |y| {
-            let y_offset = y >> 1;
-            ((left - y_offset)..=(right - y_offset)).map(move |x| Hex::new(x, y))
-        })
-    }
-
-    /// Generates a rectangle with the given bounds for "flat topped" hexagons
-    pub fn flat_rectangle([left, right, top, bottom]: [i32; 4]) -> impl Iterator<Item = Hex> {
-        (left..=right).flat_map(move |x| {
-            let x_offset = x >> 1;
-            ((top - x_offset)..=(bottom - x_offset)).map(move |y| Hex::new(x, y))
-        })
-    }
-}
+pub mod shapes;

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -1,0 +1,129 @@
+use crate::{hex::iter::ExactSizeHexIterator, Hex};
+
+/// Generates a parallelogram layout from `min` to `max`
+#[must_use]
+pub fn parallelogram(min: Hex, max: Hex) -> impl ExactSizeIterator<Item = Hex> {
+    let dist = (max.x.saturating_sub(min.x) + 1) * (max.y.saturating_sub(min.y) + 1);
+    ExactSizeHexIterator {
+        iter: (min.x()..=max.x())
+            .flat_map(move |x| (min.y()..=max.y()).map(move |y| Hex::new(x, y))),
+        count: dist as usize,
+    }
+}
+
+/// Generates a triangle with a custom `size`
+///
+/// # Note
+///
+/// To offset the map, apply the offset to each `Item` of the returned iterator
+#[allow(clippy::cast_possible_wrap)]
+#[must_use]
+pub fn triangle(size: u32) -> impl ExactSizeIterator<Item = Hex> {
+    ExactSizeHexIterator {
+        iter: (0..=size)
+            .flat_map(move |x| (0..=(size - x)).map(move |y| Hex::new(x as i32, y as i32))),
+        count: Hex::wedge_count(size) as usize,
+    }
+}
+
+/// Generates an hexagonal layout around `center` with a custom `radius`.
+#[must_use]
+pub fn hexagon(center: Hex, radius: u32) -> impl ExactSizeIterator<Item = Hex> {
+    center.range(radius)
+}
+
+/// Generates a rectangle with the given bounds for "pointy topped" hexagons.
+///
+/// The function takes four offsets as `[left, right, top, bottom]`.
+/// The generations goes `left` to `right` and `top` to `bottom`, therefore `right` must be greater
+/// than `left` and `bottom` must be greater than `top`.
+#[must_use]
+pub fn pointy_rectangle(
+    [left, right, top, bottom]: [i32; 4],
+) -> impl ExactSizeIterator<Item = Hex> {
+    let count = (right.saturating_sub(left) + 1) * (bottom.saturating_sub(top) + 1);
+    ExactSizeHexIterator {
+        iter: (top..=bottom).flat_map(move |y| {
+            let y_offset = y >> 1;
+            ((left - y_offset)..=(right - y_offset)).map(move |x| Hex::new(x, y))
+        }),
+        count: count as usize,
+    }
+}
+
+/// Generates a rectangle with the given bounds for "flat topped" hexagons
+///
+/// The function takes four offsets as `[left, right, top, bottom]`.
+/// The generations goes `left` to `right` and `top` to `bottom`, therefore `right` must be greater
+/// than `left` and `bottom` must be greater than `top`.
+#[must_use]
+pub fn flat_rectangle([left, right, top, bottom]: [i32; 4]) -> impl ExactSizeIterator<Item = Hex> {
+    let count = (right.saturating_sub(left) + 1) * (bottom.saturating_sub(top) + 1);
+    ExactSizeHexIterator {
+        iter: (left..=right).flat_map(move |x| {
+            let x_offset = x >> 1;
+            ((top - x_offset)..=(bottom - x_offset)).map(move |y| Hex::new(x, y))
+        }),
+        count: count as usize,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hexagon_test() {
+        let hex = Hex::new(3, -987);
+        for range in 0..=30 {
+            let iter = hexagon(hex, range);
+            assert_eq!(iter.len(), iter.count());
+        }
+    }
+
+    #[test]
+    fn triangle_test() {
+        for range in 0..=30 {
+            let iter = triangle(range);
+            assert_eq!(iter.len(), iter.count());
+        }
+    }
+
+    #[test]
+    fn parallelogram_test() {
+        for min in 0..=30 {
+            for max in 0..=30 {
+                let iter = parallelogram(Hex::splat(min), Hex::splat(min + max));
+                assert_eq!(iter.len(), iter.count());
+            }
+        }
+    }
+
+    #[test]
+    fn pointy_rectangle_test() {
+        for left in -20..=20 {
+            for right in 0..=20 {
+                for top in -20..-20 {
+                    for bottom in 0..=20 {
+                        let iter = pointy_rectangle([left, left + right, top, top + bottom]);
+                        assert_eq!(iter.len(), iter.count());
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn flat_rectangle_test() {
+        for left in -20..=20 {
+            for right in 0..=20 {
+                for top in -20..-20 {
+                    for bottom in 0..=20 {
+                        let iter = flat_rectangle([left, left + right, top, top + bottom]);
+                        assert_eq!(iter.len(), iter.count());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -1,7 +1,8 @@
-use crate::{hex::iter::ExactSizeHexIterator, Hex};
+use crate::{hex::ExactSizeHexIterator, Hex};
 
 /// Generates a parallelogram layout from `min` to `max`
 #[must_use]
+#[allow(clippy::cast_sign_loss)]
 pub fn parallelogram(min: Hex, max: Hex) -> impl ExactSizeIterator<Item = Hex> {
     let dist = (max.x.saturating_sub(min.x) + 1) * (max.y.saturating_sub(min.y) + 1);
     ExactSizeHexIterator {
@@ -38,6 +39,7 @@ pub fn hexagon(center: Hex, radius: u32) -> impl ExactSizeIterator<Item = Hex> {
 /// The generations goes `left` to `right` and `top` to `bottom`, therefore `right` must be greater
 /// than `left` and `bottom` must be greater than `top`.
 #[must_use]
+#[allow(clippy::cast_sign_loss)]
 pub fn pointy_rectangle(
     [left, right, top, bottom]: [i32; 4],
 ) -> impl ExactSizeIterator<Item = Hex> {
@@ -57,6 +59,7 @@ pub fn pointy_rectangle(
 /// The generations goes `left` to `right` and `top` to `bottom`, therefore `right` must be greater
 /// than `left` and `bottom` must be greater than `top`.
 #[must_use]
+#[allow(clippy::cast_sign_loss)]
 pub fn flat_rectangle([left, right, top, bottom]: [i32; 4]) -> impl ExactSizeIterator<Item = Hex> {
     let count = (right.saturating_sub(left) + 1) * (bottom.saturating_sub(top) + 1);
     ExactSizeHexIterator {
@@ -103,7 +106,7 @@ mod tests {
     fn pointy_rectangle_test() {
         for left in -20..=20 {
             for right in 0..=20 {
-                for top in -20..-20 {
+                for top in -20..=20 {
                     for bottom in 0..=20 {
                         let iter = pointy_rectangle([left, left + right, top, top + bottom]);
                         assert_eq!(iter.len(), iter.count());
@@ -117,7 +120,7 @@ mod tests {
     fn flat_rectangle_test() {
         for left in -20..=20 {
             for right in 0..=20 {
-                for top in -20..-20 {
+                for top in -20..=20 {
                     for bottom in 0..=20 {
                         let iter = flat_rectangle([left, left + right, top, top + bottom]);
                         assert_eq!(iter.len(), iter.count());


### PR DESCRIPTION
> Closes #46 

# Work Done

- [x] Added a private iterator wrapper `ExactSizeHexIterator` 
- [x] Wrapped known size iterator methods in the wrapper:
  - [x] `Hex::range`
  - [x] `Hex::line_to`
  - [x] `shapes::hexagon`  
  - [x] `HexBounds::all_coords` 
 - [x] Extend the same for rings
   - [x] ring edges 
   - [x] Added *full wedges* with exact size 
 - [x] Extend the same for other shapes where applicable