### PR TITLE
Direction utilities improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 * Added `Add<DiagonalDirection>` and `AddAssign<DiagonalDirection>` impls for `Hex` 
 * Added `Sub<Direction>` and `SubAssign<Direction>` impls for `Hex` 
 * Added `Sub<DiagonalDirection>` and `SubAssign<DiagonalDirection>` impls for `Hex` 
+* Added `Mul<i32>` for `Direction` returning its `Hex` vector multiplied
+* Added `Mul<i32>` for `DiagonalDirection` returning its `Hex` vector multiplied
 
 ### Miscellaneous
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@
 * Added `Hex::full_wedge` which returns an `ExactSizeIterator`
 * Added `Hex::custom_full_wedge` which returns an `ExactSizeIterator`
 
+### Directions
+
+* (**BREAKING**) Removed implementation of `Direction + usize` to rotate clockwise, replaced by the shift right operator `>>`
+* (**BREAKING**) Removed implementation of `DiagonalDirection + usize` to rotate clockwise, replaced by the shift right operator `>>`
+* (**BREAKING**) Removed implementation of `Direction - usize` to rotate counter clockwise, replaced by the shift left operator `<<`
+* (**BREAKING**) Removed implementation of `DiagonalDirection - usize` to rotate counter clockwise, replaced by the shift left operator `<<`
+* Added `Hex::diagonal_neigbhor`
+* Added `Hex::diagonal_neigbhor_coord`
+* Added `Add<Direction>` and `AddAssign<Direction>` impls for `Hex` 
+* Added `Add<DiagonalDirection>` and `AddAssign<DiagonalDirection>` impls for `Hex` 
+* Added `Sub<Direction>` and `SubAssign<Direction>` impls for `Hex` 
+* Added `Sub<DiagonalDirection>` and `SubAssign<DiagonalDirection>` impls for `Hex` 
+
 ### Miscellaneous
 
 * Deprecated `Hex::to_array3` in favor of `Hex::to_cubic_array`

--- a/src/direction/diagonal_direction.rs
+++ b/src/direction/diagonal_direction.rs
@@ -1,6 +1,6 @@
 #[allow(clippy::wildcard_imports)]
 use super::angles::*;
-use crate::{Direction, Hex, HexOrientation};
+use crate::{Direction, HexOrientation};
 
 /// All 6 possible diagonal directions in hexagonal space.
 /// ```txt
@@ -17,6 +17,27 @@ use crate::{Direction, Hex, HexOrientation};
 ///      / 4  \___/  5 \
 /// ```
 /// See [`Hex::DIAGONAL_COORDS`](crate::Hex::DIAGONAL_COORDS)
+///
+/// ## Operations
+///
+/// Directions can be rotated:
+///  - *clockwise* with:
+///     - [`Self::right`] and [`Self::rotate_right`]
+///     - The shift right `>>` operator
+///  - *counter clockwise* with:
+///     - [`Self::left`] and [`Self::rotate_left`]
+///     - The shift left `<<` operator
+///
+/// And negated using the minus `-` operator.
+///
+/// Example:
+/// ```rust
+/// # use hexx::*;
+/// let direction = DiagonalDirection::Right;
+/// assert_eq!(-direction, DiagonalDirection::Left);
+/// assert_eq!(direction >> 1, DiagonalDirection::BottomRight);
+/// assert_eq!(direction << 1, DiagonalDirection::TopRight);
+/// ```
 #[repr(u8)]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
@@ -44,6 +65,7 @@ pub enum DiagonalDirection {
     ///       +--+     +--+   y Axis
     ///      /    \___/    \
     /// ```
+    #[doc(alias = "East")]
     Right = 0,
     /// Direction to (1, -2)
     ///
@@ -67,6 +89,7 @@ pub enum DiagonalDirection {
     ///       +--+     +--+   y Axis
     ///      /    \___/    \
     /// ```
+    #[doc(alias = "NorthEast")]
     TopRight = 1,
     /// Direction to (-1, -1)
     ///
@@ -90,6 +113,7 @@ pub enum DiagonalDirection {
     ///       +--+     +--+   y Axis
     ///      /    \___/    \
     /// ```
+    #[doc(alias = "NorthWest")]
     TopLeft = 2,
     /// Direction to (-2, 1)
     ///
@@ -113,6 +137,7 @@ pub enum DiagonalDirection {
     ///       +--+     +--+   y Axis
     ///      /    \___/    \
     /// ```
+    #[doc(alias = "West")]
     Left = 3,
     /// Direction to (-1, 2)
     ///
@@ -136,6 +161,7 @@ pub enum DiagonalDirection {
     ///       +--+     +--+   y Axis
     ///      / X  \___/    \
     /// ```
+    #[doc(alias = "SouthWest")]
     BottomLeft = 4,
     /// Direction to (1, 1)
     ///
@@ -159,6 +185,7 @@ pub enum DiagonalDirection {
     ///       +--+     +--+   y Axis
     ///      /    \___/  X \
     /// ```
+    #[doc(alias = "SouthEast")]
     BottomRight = 5,
 }
 
@@ -380,11 +407,5 @@ impl DiagonalDirection {
             Self::BottomLeft => Direction::BottomLeft,
             Self::BottomRight => Direction::Bottom,
         }
-    }
-}
-
-impl From<DiagonalDirection> for Hex {
-    fn from(value: DiagonalDirection) -> Self {
-        Self::DIAGONAL_COORDS[value as usize]
     }
 }

--- a/src/direction/diagonal_direction.rs
+++ b/src/direction/diagonal_direction.rs
@@ -20,15 +20,15 @@ use crate::{Direction, HexOrientation};
 ///
 /// ## Operations
 ///
-/// Directions can be rotated:
-///  - *clockwise* with:
+/// Directions can be:
+///  - rotated *clockwise* with:
 ///     - [`Self::right`] and [`Self::rotate_right`]
 ///     - The shift right `>>` operator
-///  - *counter clockwise* with:
+///  - rotated *counter clockwise* with:
 ///     - [`Self::left`] and [`Self::rotate_left`]
 ///     - The shift left `<<` operator
-///
-/// And negated using the minus `-` operator.
+///  - negated using the minus `-` operator
+///  - multiplied by an `i32`, returning a [`Hex`](crate::Hex) vector
 ///
 /// Example:
 /// ```rust
@@ -190,7 +190,7 @@ pub enum DiagonalDirection {
 }
 
 impl DiagonalDirection {
-    /// All 6 diagonal directions matching [`Hex::DIAGONAL_COORDS`]
+    /// All 6 diagonal directions matching [`Hex::DIAGONAL_COORDS`](crate::Hex::DIAGONAL_COORDS)
     /// ```txt
     ///            x Axis
     ///           \___/

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -23,15 +23,15 @@ use crate::{DiagonalDirection, HexOrientation};
 ///
 /// ## Operations
 ///
-/// Directions can be rotated:
-///  - *clockwise* with:
+/// Directions can be:
+///  - rotated *clockwise* with:
 ///     - [`Self::right`] and [`Self::rotate_right`]
 ///     - The shift right `>>` operator
-///  - *counter clockwise* with:
+///  - rotated *counter clockwise* with:
 ///     - [`Self::left`] and [`Self::rotate_left`]
 ///     - The shift left `<<` operator
-///
-/// And negated using the minus `-` operator.
+///  - negated using the minus `-` operator
+///  - multiplied by an `i32`, returning a [`Hex`](crate::Hex) vector
 ///
 /// Example:
 /// ```rust

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -1,6 +1,6 @@
 #[allow(clippy::wildcard_imports)]
 use super::angles::*;
-use crate::{DiagonalDirection, Hex, HexOrientation};
+use crate::{DiagonalDirection, HexOrientation};
 
 /// All 6 possible directions in hexagonal space.
 ///
@@ -19,6 +19,28 @@ use crate::{DiagonalDirection, Hex, HexOrientation};
 /// ```
 ///
 /// See [`Hex::NEIGHBORS_COORDS`](crate::Hex::NEIGHBORS_COORDS)
+///
+///
+/// ## Operations
+///
+/// Directions can be rotated:
+///  - *clockwise* with:
+///     - [`Self::right`] and [`Self::rotate_right`]
+///     - The shift right `>>` operator
+///  - *counter clockwise* with:
+///     - [`Self::left`] and [`Self::rotate_left`]
+///     - The shift left `<<` operator
+///
+/// And negated using the minus `-` operator.
+///
+/// Example:
+/// ```rust
+/// # use hexx::*;
+/// let direction = Direction::Top;
+/// assert_eq!(-direction, Direction::Bottom);
+/// assert_eq!(direction >> 1, Direction::TopRight);
+/// assert_eq!(direction << 1, Direction::TopLeft);
+/// ```
 #[repr(u8)]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
@@ -46,6 +68,7 @@ pub enum Direction {
     ///       +--+     +--+   y Axis
     ///           \___/
     /// ```
+    #[doc(alias = "NorthEast")]
     TopRight = 0,
     /// Direction to (0, -1)
     ///
@@ -69,6 +92,7 @@ pub enum Direction {
     ///       +--+     +--+   y Axis
     ///           \___/
     /// ```
+    #[doc(alias = "North")]
     Top = 1,
     /// Direction to (-1, 0)
     ///
@@ -92,6 +116,7 @@ pub enum Direction {
     ///       +--+     +--+   y Axis
     ///           \___/
     /// ```
+    #[doc(alias = "NorthWest")]
     TopLeft = 2,
     /// Direction to (-1, 1)
     ///
@@ -115,6 +140,7 @@ pub enum Direction {
     ///       +--+     +--+   y Axis
     ///           \___/
     /// ```
+    #[doc(alias = "SouthWest")]
     BottomLeft = 3,
     /// Direction to (0, 1)
     ///
@@ -138,6 +164,7 @@ pub enum Direction {
     ///       +--+  X  +--+   y Axis
     ///           \___/
     /// ```
+    #[doc(alias = "South")]
     Bottom = 4,
     /// Drection to (1, 0)
     ///
@@ -161,6 +188,7 @@ pub enum Direction {
     ///       +--+     +--+   y Axis
     ///           \___/
     /// ```
+    #[doc(alias = "SouthEast")]
     BottomRight = 5,
 }
 
@@ -382,11 +410,5 @@ impl Direction {
             Self::Bottom => DiagonalDirection::BottomLeft,
             Self::BottomRight => DiagonalDirection::BottomRight,
         }
-    }
-}
-
-impl From<Direction> for Hex {
-    fn from(value: Direction) -> Self {
-        Self::NEIGHBORS_COORDS[value as usize]
     }
 }

--- a/src/direction/impls.rs
+++ b/src/direction/impls.rs
@@ -1,6 +1,6 @@
-use std::ops::{Neg, Shl, Shr};
+use std::ops::{Mul, Neg, Shl, Shr};
 
-use crate::{DiagonalDirection, Direction};
+use crate::{DiagonalDirection, Direction, Hex};
 
 impl Neg for DiagonalDirection {
     type Output = Self;
@@ -47,5 +47,21 @@ impl Shl<usize> for DiagonalDirection {
 
     fn shl(self, rhs: usize) -> Self::Output {
         self.rotate_left(rhs)
+    }
+}
+
+impl Mul<i32> for Direction {
+    type Output = Hex;
+
+    fn mul(self, rhs: i32) -> Self::Output {
+        Hex::from(self).mul(rhs)
+    }
+}
+
+impl Mul<i32> for DiagonalDirection {
+    type Output = Hex;
+
+    fn mul(self, rhs: i32) -> Self::Output {
+        Hex::from(self).mul(rhs)
     }
 }

--- a/src/direction/impls.rs
+++ b/src/direction/impls.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Neg, Sub};
+use std::ops::{Neg, Shl, Shr};
 
 use crate::{DiagonalDirection, Direction};
 
@@ -18,34 +18,34 @@ impl Neg for Direction {
     }
 }
 
-impl Add<usize> for Direction {
+impl Shr<usize> for Direction {
     type Output = Self;
 
-    fn add(self, rhs: usize) -> Self::Output {
+    fn shr(self, rhs: usize) -> Self::Output {
         self.rotate_right(rhs)
     }
 }
 
-impl Add<usize> for DiagonalDirection {
+impl Shr<usize> for DiagonalDirection {
     type Output = Self;
 
-    fn add(self, rhs: usize) -> Self::Output {
+    fn shr(self, rhs: usize) -> Self::Output {
         self.rotate_right(rhs)
     }
 }
 
-impl Sub<usize> for Direction {
+impl Shl<usize> for Direction {
     type Output = Self;
 
-    fn sub(self, rhs: usize) -> Self::Output {
+    fn shl(self, rhs: usize) -> Self::Output {
         self.rotate_left(rhs)
     }
 }
 
-impl Sub<usize> for DiagonalDirection {
+impl Shl<usize> for DiagonalDirection {
     type Output = Self;
 
-    fn sub(self, rhs: usize) -> Self::Output {
+    fn shl(self, rhs: usize) -> Self::Output {
         self.rotate_left(rhs)
     }
 }

--- a/src/hex/convert.rs
+++ b/src/hex/convert.rs
@@ -1,4 +1,4 @@
-use super::Hex;
+use crate::{DiagonalDirection, Direction, Hex};
 use glam::{IVec2, IVec3, Vec2};
 
 impl From<(i32, i32)> for Hex {
@@ -54,5 +54,17 @@ impl From<IVec2> for Hex {
     #[inline]
     fn from(v: IVec2) -> Self {
         Self::new(v.x, v.y)
+    }
+}
+
+impl From<Direction> for Hex {
+    fn from(value: Direction) -> Self {
+        Self::neighbor_coord(value)
+    }
+}
+
+impl From<DiagonalDirection> for Hex {
+    fn from(value: DiagonalDirection) -> Self {
+        Self::diagonal_neighbor_coord(value)
     }
 }

--- a/src/hex/impls.rs
+++ b/src/hex/impls.rs
@@ -1,4 +1,4 @@
-use super::Hex;
+use crate::{DiagonalDirection, Direction, Hex};
 use std::{
     iter::{Product, Sum},
     ops::{
@@ -28,6 +28,24 @@ impl Add<i32> for Hex {
     }
 }
 
+impl Add<Direction> for Hex {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Direction) -> Self::Output {
+        self.add(Self::from(rhs))
+    }
+}
+
+impl Add<DiagonalDirection> for Hex {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: DiagonalDirection) -> Self::Output {
+        self.add(Self::from(rhs))
+    }
+}
+
 impl AddAssign for Hex {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
@@ -38,6 +56,20 @@ impl AddAssign for Hex {
 impl AddAssign<i32> for Hex {
     #[inline]
     fn add_assign(&mut self, rhs: i32) {
+        *self = self.add(rhs);
+    }
+}
+
+impl AddAssign<Direction> for Hex {
+    #[inline]
+    fn add_assign(&mut self, rhs: Direction) {
+        *self = self.add(rhs);
+    }
+}
+
+impl AddAssign<DiagonalDirection> for Hex {
+    #[inline]
+    fn add_assign(&mut self, rhs: DiagonalDirection) {
         *self = self.add(rhs);
     }
 }
@@ -75,6 +107,24 @@ impl Sub<i32> for Hex {
     }
 }
 
+impl Sub<Direction> for Hex {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Direction) -> Self::Output {
+        self.sub(Self::from(rhs))
+    }
+}
+
+impl Sub<DiagonalDirection> for Hex {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: DiagonalDirection) -> Self::Output {
+        self.sub(Self::from(rhs))
+    }
+}
+
 impl SubAssign for Hex {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
@@ -85,6 +135,20 @@ impl SubAssign for Hex {
 impl SubAssign<i32> for Hex {
     #[inline]
     fn sub_assign(&mut self, rhs: i32) {
+        *self = self.sub(rhs);
+    }
+}
+
+impl SubAssign<Direction> for Hex {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Direction) {
+        *self = self.sub(rhs);
+    }
+}
+
+impl SubAssign<DiagonalDirection> for Hex {
+    #[inline]
+    fn sub_assign(&mut self, rhs: DiagonalDirection) {
         *self = self.sub(rhs);
     }
 }

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -531,6 +531,13 @@ impl Hex {
 
     #[inline]
     #[must_use]
+    /// Retrieves the diagonal neighbor coordinates matching the given `direction`
+    pub const fn diagonal_neighbor_coord(direction: DiagonalDirection) -> Self {
+        Self::DIAGONAL_COORDS[direction as usize]
+    }
+
+    #[inline]
+    #[must_use]
     /// Retrieves the neighbor coordinates matching the given `direction`
     ///
     /// # Example
@@ -543,6 +550,22 @@ impl Hex {
     /// ```
     pub const fn neighbor(self, direction: Direction) -> Self {
         self.const_add(Self::neighbor_coord(direction))
+    }
+
+    #[inline]
+    #[must_use]
+    /// Retrieves the diagonal neighbor coordinates matching the given `direction`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let coord = Hex::new(10, 5);
+    /// let bottom = coord.diagonal_neighbor(DiagonalDirection::Right);
+    /// assert_eq!(bottom, Hex::new(12, 4));
+    /// ```
+    pub const fn diagonal_neighbor(self, direction: DiagonalDirection) -> Self {
+        self.const_add(Self::diagonal_neighbor_coord(direction))
     }
 
     #[inline]

--- a/src/hex/rings.rs
+++ b/src/hex/rings.rs
@@ -111,10 +111,10 @@ impl Hex {
     ) -> impl ExactSizeIterator<Item = Self> {
         let [start_dir, end_dir] = if clockwise {
             let dir = direction.direction_left();
-            [dir, dir + 2]
+            [dir, dir >> 2]
         } else {
             let dir = direction.direction_right();
-            [dir, dir - 2]
+            [dir, dir << 2]
         };
         let end_dir = Self::neighbor_coord(end_dir);
         let hex = self + Self::neighbor_coord(start_dir) * radius as i32;

--- a/src/hex/rings.rs
+++ b/src/hex/rings.rs
@@ -26,7 +26,7 @@ impl Hex {
             directions.rotate_left(2);
         }
 
-        let mut hex = self + Self::neighbor_coord(start_dir) * range as i32;
+        let mut hex = self + start_dir * range as i32;
         let mut res = Vec::with_capacity(Self::ring_count(range));
         for dir in directions {
             (0..range).for_each(|_| {
@@ -116,8 +116,7 @@ impl Hex {
             let dir = direction.direction_right();
             [dir, dir << 2]
         };
-        let end_dir = Self::neighbor_coord(end_dir);
-        let hex = self + Self::neighbor_coord(start_dir) * radius as i32;
+        let hex = self + start_dir * radius as i32;
         ExactSizeHexIterator {
             iter: (0..=radius).map(move |i| hex + end_dir * i as i32),
             count: radius as usize + 1,


### PR DESCRIPTION
Global improvements for hexagonal directions:

We can now add `Hex` and directions like :

```rust
let hex = Hex::ZERO + Direction::Top;
```

And multiply directions to have:

```rust
let hex = Hex::ZERO + Direction::TOP * 8;
```

I removed the previous rotation operators for directions which wer `+` and `-` and replaced them by the shifting operators `>>` and `<<` to avoid confusion. I also added documentation for these new operations 
