### PR TITLE
Hex swizzle methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## Unreleased
 
 * Improved `README` examples section
+* Added `Hex` swizzle methods:
+  * `xx`
+  * `yy`
+  * `zz`
+  * `yx`
+  * `yz`
+  * `xz`
+  * `zx`
+  * `zy`
 
 ## 0.5.2 
 

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -6,6 +6,8 @@ mod impls;
 mod iter;
 /// Hex ring utils
 mod rings;
+/// swizzle utils
+mod siwzzle;
 #[cfg(test)]
 mod tests;
 

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -651,6 +651,15 @@ impl Hex {
     #[inline]
     #[must_use]
     /// Rotates `self` around [`Hex::ZERO`] counter clockwise (by -60 degrees)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let hex = Hex::new(1, 2);
+    /// assert_eq!(hex.left(), Hex::new(3, -1));
+    /// ```
     pub const fn left(self) -> Self {
         Self::new(-self.z(), -self.x)
     }
@@ -686,6 +695,15 @@ impl Hex {
     #[inline]
     #[must_use]
     /// Rotates `self` around [`Hex::ZERO`] clockwise (by 60 degrees)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let hex = Hex::new(1, 2);
+    /// assert_eq!(hex.right(), Hex::new(-2, 3));
+    /// ```
     pub const fn right(self) -> Self {
         Self::new(-self.y, -self.z())
     }

--- a/src/hex/siwzzle.rs
+++ b/src/hex/siwzzle.rs
@@ -1,0 +1,154 @@
+use super::Hex;
+
+impl Hex {
+    #[inline]
+    #[must_use]
+    #[doc(alias = "qq")]
+    /// Returns a new [`Hex`] with both `x` and `y` set to the current `x` value
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let hex = Hex::new(1, 2);
+    /// assert_eq!(hex.xx(), Hex::new(1, 1));
+    /// ```
+    pub const fn xx(self) -> Self {
+        Self::splat(self.x)
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "rr")]
+    /// Returns a new [`Hex`] with both `x` and `y` set to the current `y` value
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let hex = Hex::new(1, 2);
+    /// assert_eq!(hex.yy(), Hex::new(2, 2));
+    /// ```
+    pub const fn yy(self) -> Self {
+        Self::splat(self.y)
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "ss")]
+    /// Returns a new [`Hex`] with both `x` and `y` set to the current `z` value
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let hex = Hex::new(1, 2);
+    /// assert_eq!(hex.zz(), Hex::new(-3, -3));
+    /// ```
+    pub const fn zz(self) -> Self {
+        Self::splat(self.z())
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "rq")]
+    /// Returns a new [`Hex`] with invertex `x` and `y` values
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let hex = Hex::new(1, 2);
+    /// assert_eq!(hex.yx(), Hex::new(2, 1));
+    /// ```
+    pub const fn yx(self) -> Self {
+        Self {
+            x: self.y,
+            y: self.x,
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "rs")]
+    /// Returns a new [`Hex`] with its `y` valye as `x` and its `z` value as `y`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let hex = Hex::new(1, 2);
+    /// assert_eq!(hex.yz(), Hex::new(2, -3));
+    /// ```
+    pub const fn yz(self) -> Self {
+        Self {
+            x: self.y,
+            y: self.z(),
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "qs")]
+    /// Returns a new [`Hex`] with its `z` value as `y`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let hex = Hex::new(1, 2);
+    /// assert_eq!(hex.xz(), Hex::new(1, -3));
+    /// ```
+    pub const fn xz(self) -> Self {
+        Self {
+            x: self.x,
+            y: self.z(),
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "sq")]
+    /// Returns a new [`Hex`] with its `z` value as `x` and its `x` value as `y`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let hex = Hex::new(1, 2);
+    /// assert_eq!(hex.zx(), Hex::new(-3, 1));
+    /// ```
+    pub const fn zx(self) -> Self {
+        Self {
+            x: self.z(),
+            y: self.x,
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "sr")]
+    /// Returns a new [`Hex`] with its `z` value as `x`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let hex = Hex::new(1, 2);
+    /// assert_eq!(hex.zy(), Hex::new(-3, 2));
+    /// ```
+    pub const fn zy(self) -> Self {
+        Self {
+            x: self.z(),
+            y: self.y,
+        }
+    }
+}


### PR DESCRIPTION
* Added `Hex` swizzle methods:
  * `xx`
  * `yy`
  * `zz`
  * `yx`
  * `yz`
  * `xz`
  * `zx`
  * `zy`
