### PR TITLE
Drop itertools deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 * Changed logo (#63)
+* Drop `itertools` dependency
+* Removed deprecated `Hex::directions_to` method
 
 ## 0.5.3 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ ser_de = ["serde", "glam/serde"]
 
 [dependencies]
 glam = "0.23"
-itertools = "0.10"
 
 [dependencies.serde]
 version = "1"

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -16,7 +16,6 @@ pub use iter::HexIterExt;
 
 use crate::{DiagonalDirection, Direction};
 use glam::{IVec2, IVec3, Vec2};
-use itertools::Itertools;
 use std::cmp::{max, min};
 
 /// Hexagonal [axial] coordinates
@@ -589,18 +588,6 @@ impl Hex {
         Direction::iter().find(|&dir| self.neighbor(dir) == other)
     }
 
-    #[inline]
-    #[deprecated(
-        since = "0.5.3",
-        note = "0.6.0 will drop this method, open an issue if you are using it"
-    )]
-    /// Retrieves all directions in the line between `self` and `other`
-    pub fn directions_to(self, other: Self) -> impl Iterator<Item = Direction> {
-        self.line_to(other)
-            .tuple_windows::<(_, _)>()
-            .filter_map(|(a, b)| a.neighbor_direction(b))
-    }
-
     #[must_use]
     /// Find in which [`DiagonalDirection`] wedge `rhs` is relative to `self`
     pub fn diagonal_to(self, rhs: Self) -> DiagonalDirection {
@@ -859,13 +846,9 @@ impl Hex {
         }
         let mut res = self;
         while res.ulength() > radius {
-            let mirror = mirrors
-                .iter()
-                .copied()
-                .sorted_unstable_by_key(|m| res.distance_to(*m))
-                .next()
-                .unwrap(); // Safe
-            res -= mirror;
+            let mut mirror = mirrors.to_vec();
+            mirrors.sort_unstable_by_key(|m| res.distance_to(*m));
+            res -= mirrors[0];
         }
         res
     }

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -846,7 +846,7 @@ impl Hex {
         }
         let mut res = self;
         while res.ulength() > radius {
-            let mut mirror = mirrors.to_vec();
+            let mut mirrors = mirrors.to_vec();
             mirrors.sort_unstable_by_key(|m| res.distance_to(*m));
             res -= mirrors[0];
         }

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -368,28 +368,6 @@ fn empty_line_to() {
 }
 
 #[test]
-#[allow(deprecated)]
-fn directions_to() {
-    let a = Hex::new(0, 0);
-    let b = Hex::new(5, 5);
-    assert_eq!(
-        a.directions_to(b).collect::<Vec<_>>(),
-        vec![
-            Direction::Bottom,
-            Direction::BottomRight,
-            Direction::Bottom,
-            Direction::BottomRight,
-            Direction::Bottom,
-            Direction::BottomRight,
-            Direction::Bottom,
-            Direction::BottomRight,
-            Direction::Bottom,
-            Direction::BottomRight
-        ]
-    );
-}
-
-#[test]
 fn range_count() {
     assert_eq!(Hex::range_count(0), 1);
     assert_eq!(Hex::range_count(1), 7);


### PR DESCRIPTION
The `itertools` dependency is not very useful

# Work done

- Cleaned `Hex::wrap_with` to use `Vec` instead of a temporary iterator in `itertools`
- Removed deprecated niche method `Hex::directions_to`