### PR TITLE
2d examples use 2d rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,15 @@
 ## Unreleased
 
 * Changed logo (#63)
-* Drop `itertools` dependency
-* Removed deprecated `Hex::directions_to` method
+* Drop `itertools` dependency (#58)
+* Removed deprecated `Hex::directions_to` method (#58)
+* added `MeshInfo::facing` utils method to rotate hex meshes
+
+### Examples
+
+* `hex_grid` example now uses a 2d mesh and camera
+* `scroll_map` example now uses a 2d mesh and camera
+* `wrap_map` example now uses a 2d mesh and camera
 
 ## 0.5.3 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 * Changed logo (#63)
 * Drop `itertools` dependency (#58)
 * Removed deprecated `Hex::directions_to` method (#58)
-* added `MeshInfo::facing` utils method to rotate hex meshes
+* added `MeshInfo::facing` utils method to rotate hex meshes (#65)
 
 ### Examples
 
-* `hex_grid` example now uses a 2d mesh and camera
-* `scroll_map` example now uses a 2d mesh and camera
-* `wrap_map` example now uses a 2d mesh and camera
+* `hex_grid` example now uses a 2d mesh and camera (#65)
+* `scroll_map` example now uses a 2d mesh and camera (#65)
+* `wrap_map` example now uses a 2d mesh and camera (#65)
 
 ## 0.5.3 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ optional = true
 # For lib.rs doctests and examples
 [dev-dependencies.bevy]
 version = "0.10"
-features = ["bevy_render", "bevy_pbr", "bevy_core_pipeline", "bevy_asset", "bevy_winit", "x11"]
+features = ["bevy_render", "bevy_pbr", "bevy_sprite", "bevy_core_pipeline", "bevy_asset", "bevy_winit", "x11"]
 default-features = false
 
 [dev-dependencies.criterion]

--- a/examples/3d_columns.rs
+++ b/examples/3d_columns.rs
@@ -19,7 +19,7 @@ const TIME_STEP: Duration = Duration::from_millis(100);
 pub fn main() {
     App::new()
         .insert_resource(AmbientLight {
-            brightness: 1.0,
+            brightness: 0.1,
             ..default()
         })
         .add_plugins(DefaultPlugins)
@@ -44,8 +44,13 @@ struct HighlightedHexes {
 
 /// 3D Orthogrpahic camera setup
 fn setup_camera(mut commands: Commands) {
+    let transform = Transform::from_xyz(0.0, 60.0, 60.0).looking_at(Vec3::ZERO, Vec3::Y);
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 50.0, 50.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform,
+        ..default()
+    });
+    commands.spawn(DirectionalLightBundle {
+        transform,
         ..default()
     });
 }
@@ -72,7 +77,8 @@ fn setup_grid(
             let pos = layout.hex_to_world_pos(hex);
             let id = commands
                 .spawn(PbrBundle {
-                    transform: Transform::from_xyz(pos.x, 0.0, pos.y).with_scale(Vec3::splat(0.9)),
+                    transform: Transform::from_xyz(pos.x, hex.length() as f32 / 2.0, pos.y)
+                        .with_scale(Vec3::splat(0.9)),
                     mesh: mesh_handle.clone(),
                     material: default_material.clone(),
                     ..default()

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -12,10 +12,6 @@ const HEX_SIZE: Vec2 = Vec2::splat(8.0);
 
 pub fn main() {
     App::new()
-        .insert_resource(AmbientLight {
-            brightness: 1.0,
-            ..default()
-        })
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 resolution: (1_000.0, 1_000.0).into(),
@@ -45,29 +41,25 @@ struct HighlightedHexes {
 struct Map {
     layout: HexLayout,
     entities: HashMap<Hex, Entity>,
-    selected_material: Handle<StandardMaterial>,
-    ring_material: Handle<StandardMaterial>,
-    wedge_material: Handle<StandardMaterial>,
-    dir_wedge_material: Handle<StandardMaterial>,
-    line_material: Handle<StandardMaterial>,
-    half_ring_material: Handle<StandardMaterial>,
-    default_material: Handle<StandardMaterial>,
+    selected_material: Handle<ColorMaterial>,
+    ring_material: Handle<ColorMaterial>,
+    wedge_material: Handle<ColorMaterial>,
+    dir_wedge_material: Handle<ColorMaterial>,
+    line_material: Handle<ColorMaterial>,
+    half_ring_material: Handle<ColorMaterial>,
+    default_material: Handle<ColorMaterial>,
 }
 
 /// 3D Orthogrpahic camera setup
 fn setup_camera(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 10.0, 0.0).looking_at(Vec3::ZERO, -Vec3::Z),
-        projection: OrthographicProjection::default().into(),
-        ..default()
-    });
+    commands.spawn(Camera2dBundle::default());
 }
 
 /// Hex grid setup
 fn setup_grid(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let layout = HexLayout {
         hex_size: HEX_SIZE,
@@ -89,9 +81,9 @@ fn setup_grid(
         .map(|hex| {
             let pos = layout.hex_to_world_pos(hex);
             let id = commands
-                .spawn(PbrBundle {
-                    transform: Transform::from_xyz(pos.x, 0.0, pos.y).with_scale(Vec3::splat(0.9)),
-                    mesh: mesh_handle.clone(),
+                .spawn(ColorMesh2dBundle {
+                    transform: Transform::from_xyz(pos.x, pos.y, 0.0).with_scale(Vec3::splat(0.9)),
+                    mesh: mesh_handle.clone().into(),
                     material: default_material.clone(),
                     ..default()
                 })
@@ -121,8 +113,7 @@ fn handle_input(
 ) {
     let window = windows.single();
     if let Some(pos) = window.cursor_position() {
-        let pos = Vec2::new(pos.x, window.height() - pos.y)
-            - Vec2::new(window.width(), window.height()) / 2.0;
+        let pos = pos - Vec2::new(window.width(), window.height()) / 2.0;
         let hex = map.layout.world_pos_to_hex(pos);
         if let Some(entity) = map.entities.get(&hex).copied() {
             if hex == highlighted_hexes.selected {
@@ -191,7 +182,7 @@ fn handle_input(
 
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
-    let mesh_info = MeshInfo::hexagonal_plane(hex_layout, Hex::ZERO);
+    let mesh_info = MeshInfo::hexagonal_plane(hex_layout, Hex::ZERO).facing(Vec3::Z);
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices.to_vec());
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals.to_vec());

--- a/examples/scroll_map.rs
+++ b/examples/scroll_map.rs
@@ -12,10 +12,6 @@ const MAP_RADIUS: u32 = 10;
 
 pub fn main() {
     App::new()
-        .insert_resource(AmbientLight {
-            brightness: 1.0,
-            ..default()
-        })
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 resolution: (1_000.0, 1_000.0).into(),
@@ -38,17 +34,13 @@ struct HexGrid {
 
 /// 3D Orthogrpahic camera setup
 fn setup_camera(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 10.0, 0.0).looking_at(Vec3::ZERO, -Vec3::Z),
-        projection: OrthographicProjection::default().into(),
-        ..default()
-    });
+    commands.spawn(Camera2dBundle::default());
 }
 
 fn setup_grid(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let layout = HexLayout {
         hex_size: HEX_SIZE,
@@ -65,10 +57,10 @@ fn setup_grid(
             let material = materials.add(color.into());
             let pos = layout.hex_to_world_pos(hex);
             let entity = commands
-                .spawn(MaterialMeshBundle {
-                    mesh: mesh.clone(),
+                .spawn(ColorMesh2dBundle {
+                    mesh: mesh.clone().into(),
                     material,
-                    transform: Transform::from_xyz(pos.x, 0.0, pos.y),
+                    transform: Transform::from_xyz(pos.x, pos.y, 0.0),
                     ..default()
                 })
                 .id();
@@ -90,22 +82,21 @@ fn handle_input(
 ) {
     let window = windows.single();
     if let Some(pos) = window.cursor_position() {
-        let pos = Vec2::new(pos.x, window.height() - pos.y)
-            - Vec2::new(window.width(), window.height()) / 2.0;
+        let pos = pos - Vec2::new(window.width(), window.height()) / 2.0;
         let hex_pos = grid.layout.world_pos_to_hex(pos);
         for h in hex_pos.range(grid.wrap_map.bounds().radius) {
             let wrapped = grid.wrap_map.wrapped_hex(h);
             let pos = grid.layout.hex_to_world_pos(h);
             commands
                 .entity(grid.entities[&wrapped])
-                .insert(Transform::from_xyz(pos.x, 0.0, pos.y));
+                .insert(Transform::from_xyz(pos.x, pos.y, 0.0));
         }
     }
 }
 
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
-    let mesh_info = MeshInfo::hexagonal_plane(hex_layout, Hex::ZERO);
+    let mesh_info = MeshInfo::hexagonal_plane(hex_layout, Hex::ZERO).facing(Vec3::Z);
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices.to_vec());
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals.to_vec());

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,5 +1,8 @@
 use crate::{Hex, HexLayout};
-use glam::{Vec2, Vec3};
+use glam::{Quat, Vec2, Vec3};
+
+const UP_VECTOR: [f32; 3] = [0.0, 1.0, 0.0];
+const DOWN_VECTOR: [f32; 3] = [0.0, -1.0, 0.0];
 
 #[derive(Debug, Clone)]
 /// Mesh information. The `const LEN` attribute ensures that there is the same number of vertices, normals and uvs
@@ -12,6 +15,34 @@ pub struct MeshInfo<const LEN: usize> {
     pub uvs: [[f32; 2]; LEN],
     /// Vertex indices for triangles
     pub indices: Vec<u16>,
+    /// Direction the mesh is facing
+    facing: [f32; 3],
+}
+
+impl<const LEN: usize> MeshInfo<LEN> {
+    /// Returns a new [`MeshInfo`] but rotated in order to face `facing` direction
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `facing` is zero length
+    #[inline]
+    #[must_use]
+    pub fn facing(self, facing: Vec3) -> Self {
+        let current_facing = Vec3::from_array(self.facing);
+        let facing = facing.normalize();
+        let rotation = Quat::from_rotation_arc(current_facing, facing);
+
+        Self {
+            vertices: self
+                .vertices
+                .map(|v| rotation.mul_vec3(Vec3::from_array(v)).to_array()),
+            normals: self
+                .normals
+                .map(|n| rotation.mul_vec3(Vec3::from_array(n)).to_array()),
+            facing: facing.to_array(),
+            ..self
+        }
+    }
 }
 
 impl MeshInfo<7> {
@@ -42,7 +73,7 @@ impl MeshInfo<7> {
                 (corners[4] + uv_delta).to_array(),
                 (corners[5] + uv_delta).to_array(),
             ],
-            normals: [[0., 1., 0.]; 7],
+            normals: [UP_VECTOR; 7],
             indices: vec![
                 1, 0, 2, // 1
                 2, 0, 3, // 2
@@ -51,6 +82,7 @@ impl MeshInfo<7> {
                 5, 0, 6, // 5
                 6, 0, 1, // 6
             ],
+            facing: UP_VECTOR,
         }
     }
 }
@@ -175,13 +207,13 @@ impl MeshInfo<31> {
             ],
             normals: [
                 // Top face
-                [0., 1., 0.],
-                [0., 1., 0.],
-                [0., 1., 0.],
-                [0., 1., 0.],
-                [0., 1., 0.],
-                [0., 1., 0.],
-                [0., 1., 0.],
+                UP_VECTOR,
+                UP_VECTOR,
+                UP_VECTOR,
+                UP_VECTOR,
+                UP_VECTOR,
+                UP_VECTOR,
+                UP_VECTOR,
                 // Quad 0
                 quad_normals[0],
                 quad_normals[0],
@@ -214,6 +246,7 @@ impl MeshInfo<31> {
                 quad_normals[5],
             ],
             indices,
+            facing: UP_VECTOR,
         }
     }
 }
@@ -280,7 +313,7 @@ impl MeshInfo<13> {
         Self {
             vertices,
             normals: [
-                [0., 1., 0.],
+                UP_VECTOR,
                 quad_normals[0],
                 quad_normals[1],
                 quad_normals[2],
@@ -296,6 +329,7 @@ impl MeshInfo<13> {
             ],
             uvs: [[0., 1.]; 13], // TODO: Find decent UV mapping
             indices,
+            facing: UP_VECTOR,
         }
     }
 }
@@ -445,13 +479,13 @@ impl MeshInfo<38> {
             ],
             normals: [
                 // Top face
-                [0., 1., 0.],
-                [0., 1., 0.],
-                [0., 1., 0.],
-                [0., 1., 0.],
-                [0., 1., 0.],
-                [0., 1., 0.],
-                [0., 1., 0.],
+                UP_VECTOR,
+                UP_VECTOR,
+                UP_VECTOR,
+                UP_VECTOR,
+                UP_VECTOR,
+                UP_VECTOR,
+                UP_VECTOR,
                 // Quad 0
                 quad_normals[0],
                 quad_normals[0],
@@ -483,15 +517,16 @@ impl MeshInfo<38> {
                 quad_normals[5],
                 quad_normals[5],
                 // Bottom face
-                [0., -1., 0.],
-                [0., -1., 0.],
-                [0., -1., 0.],
-                [0., -1., 0.],
-                [0., -1., 0.],
-                [0., -1., 0.],
-                [0., -1., 0.],
+                DOWN_VECTOR,
+                DOWN_VECTOR,
+                DOWN_VECTOR,
+                DOWN_VECTOR,
+                DOWN_VECTOR,
+                DOWN_VECTOR,
+                DOWN_VECTOR,
             ],
             indices,
+            facing: UP_VECTOR,
         }
     }
 }


### PR DESCRIPTION
> Adresses #64 

# Work done

* added `MeshInfo::facing` utils method to rotate hex meshes
* `hex_grid` example now uses a 2d mesh and camera
* `scroll_map` example now uses a 2d mesh and camera
* `wrap_map` example now uses a 2d mesh and camera
