### PR TITLE
Global hex constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 * Changed logo (#63)
 * Drop `itertools` dependency (#58)
 * Removed deprecated `Hex::directions_to` method (#58)
-* added `MeshInfo::facing` utils method to rotate hex meshes (#65)
+* Added `MeshInfo::facing` utils method to rotate hex meshes (#65)
+* Added `hex` utils function to create an `Hex`, making it less boilerplate (#66):
+  - Before: `Hex::new()`
+  - Now: `hex()`
+* `Hex` won't derive `Debug` or `Hash` on spirv archs (#66)
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@
  };
  // Get the hex coordinate at the world position `world_pos`.
  let world_pos = Vec2::new(53.52, 189.28);
- let hex = layout.world_pos_to_hex(world_pos);
- // Get the world position of `hex`
- let hex = hex(123, 45);
- let world_pos = layout.hex_to_world_pos(hex);
+ let point = layout.world_pos_to_hex(world_pos);
+ // Get the world position of `point`
+ let point = hex(123, 45);
+ let world_pos = layout.hex_to_world_pos(point);
 ```
 
  ## Usage in [Bevy](https://bevyengine.org/)

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@
  use hexx::*;
 
  // Declare points in hexagonal spaces
- let point_a = Hex::new(10, -5);
- let point_b = Hex::new(-8, 15);
+ let point_a = hex(10, -5); // Equivalent of `Hex::new(10, -5)`
+ let point_b = hex(-8, 15);
  // Find distance between them
  let dist = point_a.unsigned_distance_to(point_b);
  // Compute a line between points
@@ -100,7 +100,7 @@
  let world_pos = Vec2::new(53.52, 189.28);
  let hex = layout.world_pos_to_hex(world_pos);
  // Get the world position of `hex`
- let hex = Hex::new(123, 45);
+ let hex = hex(123, 45);
  let world_pos = layout.hex_to_world_pos(hex);
 ```
 

--- a/benches/lines.rs
+++ b/benches/lines.rs
@@ -8,8 +8,8 @@ pub fn line_benchmark(c: &mut Criterion) {
 
     group.bench_with_input(BenchmarkId::new("Line", dist), &dist, |b, dist| {
         b.iter(|| {
-            let hex = black_box(Hex::ZERO);
-            hex.line_to(black_box(Hex::splat(*dist)))
+            let p = black_box(Hex::ZERO);
+            p.line_to(black_box(Hex::splat(*dist)))
         })
     });
     group.finish();

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -114,9 +114,9 @@ fn handle_input(
     let window = windows.single();
     if let Some(pos) = window.cursor_position() {
         let pos = pos - Vec2::new(window.width(), window.height()) / 2.0;
-        let hex = map.layout.world_pos_to_hex(pos);
-        if let Some(entity) = map.entities.get(&hex).copied() {
-            if hex == highlighted_hexes.selected {
+        let coord = map.layout.world_pos_to_hex(pos);
+        if let Some(entity) = map.entities.get(&coord).copied() {
+            if coord == highlighted_hexes.selected {
                 return;
             }
             // Clear highlighted hexes materials
@@ -141,17 +141,17 @@ fn handle_input(
                 .entity(map.entities[&highlighted_hexes.halfway])
                 .insert(map.default_material.clone());
             // Draw a  line
-            highlighted_hexes.line = Hex::ZERO.line_to(hex).collect();
+            highlighted_hexes.line = Hex::ZERO.line_to(coord).collect();
             // Draw a ring
-            highlighted_hexes.ring = Hex::ZERO.ring(hex.ulength());
+            highlighted_hexes.ring = Hex::ZERO.ring(coord.ulength());
             // Draw an wedge
-            highlighted_hexes.wedge = Hex::ZERO.wedge_to(hex).collect();
+            highlighted_hexes.wedge = Hex::ZERO.wedge_to(coord).collect();
             // Draw a half ring
-            highlighted_hexes.half_ring = Hex::ZERO.ring(hex.ulength() / 2);
+            highlighted_hexes.half_ring = Hex::ZERO.ring(coord.ulength() / 2);
             // Draw rotations
-            highlighted_hexes.rotated = (1..6).map(|i| hex.rotate_right(i)).collect();
+            highlighted_hexes.rotated = (1..6).map(|i| coord.rotate_right(i)).collect();
             // Draw an dual wedge
-            highlighted_hexes.dir_wedge = Hex::ZERO.corner_wedge_to(hex / 2).collect();
+            highlighted_hexes.dir_wedge = Hex::ZERO.corner_wedge_to(coord / 2).collect();
             for (vec, mat) in [
                 (&highlighted_hexes.ring, &map.ring_material),
                 (&highlighted_hexes.wedge, &map.wedge_material),
@@ -167,7 +167,7 @@ fn handle_input(
                 }
             }
             // Make the half selction red
-            highlighted_hexes.halfway = hex / 2;
+            highlighted_hexes.halfway = coord / 2;
             commands
                 .entity(map.entities[&highlighted_hexes.halfway])
                 .insert(map.selected_material.clone());
@@ -175,7 +175,7 @@ fn handle_input(
             commands
                 .entity(entity)
                 .insert(map.selected_material.clone());
-            highlighted_hexes.selected = hex;
+            highlighted_hexes.selected = coord;
         }
     }
 }

--- a/src/hex/convert.rs
+++ b/src/hex/convert.rs
@@ -4,14 +4,14 @@ use glam::{IVec2, IVec3, Vec2};
 impl From<(i32, i32)> for Hex {
     #[inline]
     fn from((x, y): (i32, i32)) -> Self {
-        Self { x, y }
+        Self::new(x, y)
     }
 }
 
 impl From<[i32; 2]> for Hex {
     #[inline]
-    fn from([x, y]: [i32; 2]) -> Self {
-        Self { x, y }
+    fn from(a: [i32; 2]) -> Self {
+        Self::from_array(a)
     }
 }
 

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::inline_always)]
 /// Type conversions
 mod convert;
 /// Traits implementations
@@ -42,13 +43,31 @@ use std::cmp::{max, min};
 ///
 /// [comparison]: https://www.redblobgames.com/grids/hexagons/#coordinates-comparison
 /// [axial]: https://www.redblobgames.com/grids/hexagons/#coordinates-axial
-#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[cfg_attr(not(target_arch = "spirv"), derive(Debug, Hash))]
 #[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hex {
     /// `x` axial coordinate (sometimes called `q` or `i`)
     pub x: i32,
     /// `y` axial coordinate (sometimes called `r` or `j`)
     pub y: i32,
+}
+
+#[inline(always)]
+#[must_use]
+/// Instantiates a new hexagon from axial coordinates
+///
+/// # Example
+///
+/// ```rust
+/// # use hexx::*;
+/// let coord = hex(3, 5);
+/// assert_eq!(coord.x, 3);
+/// assert_eq!(coord.y, 5);
+/// assert_eq!(coord.z(), -3-5);
+/// ```
+pub const fn hex(x: i32, y: i32) -> Hex {
+    Hex::new(x, y)
 }
 
 impl Hex {
@@ -125,7 +144,7 @@ impl Hex {
         Self::ONE,
     ];
 
-    #[inline]
+    #[inline(always)]
     #[must_use]
     /// Instantiates a new hexagon from axial coordinates
     ///
@@ -210,6 +229,22 @@ impl Hex {
 
     #[inline]
     #[must_use]
+    /// Creates a [`Hex`] from an array
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let hex = Hex::from_array([3, 5]);
+    /// assert_eq!(hex.x, 3);
+    /// assert_eq!(hex.y, 5);
+    /// ```
+    pub const fn from_array([x, y]: [i32; 2]) -> Self {
+        Self::new(x, y)
+    }
+
+    #[inline]
+    #[must_use]
     /// Converts `self` to an array as `[x, y]`
     ///
     /// # Example
@@ -251,7 +286,7 @@ impl Hex {
         self.to_cubic_array()
     }
 
-    // Creates a [`Hex`] from the first 2 values in `slice`.
+    /// Creates a [`Hex`] from the first 2 values in `slice`.
     ///
     /// # Panics
     ///

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -235,9 +235,9 @@ impl Hex {
     ///
     /// ```rust
     /// # use hexx::*;
-    /// let hex = Hex::from_array([3, 5]);
-    /// assert_eq!(hex.x, 3);
-    /// assert_eq!(hex.y, 5);
+    /// let p = Hex::from_array([3, 5]);
+    /// assert_eq!(p.x, 3);
+    /// assert_eq!(p.y, 5);
     /// ```
     pub const fn from_array([x, y]: [i32; 2]) -> Self {
         Self::new(x, y)
@@ -683,8 +683,8 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let hex = Hex::new(1, 2);
-    /// assert_eq!(hex.left(), Hex::new(3, -1));
+    /// let p = Hex::new(1, 2);
+    /// assert_eq!(p.left(), Hex::new(3, -1));
     /// ```
     pub const fn left(self) -> Self {
         Self::new(-self.z(), -self.x)
@@ -727,8 +727,8 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let hex = Hex::new(1, 2);
-    /// assert_eq!(hex.right(), Hex::new(-2, 3));
+    /// let p = Hex::new(1, 2);
+    /// assert_eq!(p.right(), Hex::new(-2, 3));
     /// ```
     pub const fn right(self) -> Self {
         Self::new(-self.y, -self.z())

--- a/src/hex/rings.rs
+++ b/src/hex/rings.rs
@@ -26,12 +26,12 @@ impl Hex {
             directions.rotate_left(2);
         }
 
-        let mut hex = self + start_dir * range as i32;
+        let mut point = self + start_dir * range as i32;
         let mut res = Vec::with_capacity(Self::ring_count(range));
         for dir in directions {
             (0..range).for_each(|_| {
-                res.push(hex);
-                hex += dir;
+                res.push(point);
+                point += dir;
             });
         }
         res
@@ -116,9 +116,9 @@ impl Hex {
             let dir = direction.direction_right();
             [dir, dir << 2]
         };
-        let hex = self + start_dir * radius as i32;
+        let p = self + start_dir * radius as i32;
         ExactSizeHexIterator {
-            iter: (0..=radius).map(move |i| hex + end_dir * i as i32),
+            iter: (0..=radius).map(move |i| p + end_dir * i as i32),
             count: radius as usize + 1,
         }
     }
@@ -243,8 +243,8 @@ impl Hex {
     ///
     /// ```rust
     /// # use hexx::*;
-    /// let hex = Hex::new(3, -6);
-    /// let wedge: Vec<Hex> = hex.wedge(0..=13, DiagonalDirection::Right).collect();
+    /// let point = Hex::new(3, -6);
+    /// let wedge: Vec<Hex> = point.wedge(0..=13, DiagonalDirection::Right).collect();
     /// assert_eq!(wedge.len(), Hex::wedge_count(13) as usize);
     /// ```
     #[inline]

--- a/src/hex/siwzzle.rs
+++ b/src/hex/siwzzle.rs
@@ -11,8 +11,8 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let hex = Hex::new(1, 2);
-    /// assert_eq!(hex.xx(), Hex::new(1, 1));
+    /// let point = Hex::new(1, 2);
+    /// assert_eq!(point.xx(), Hex::new(1, 1));
     /// ```
     pub const fn xx(self) -> Self {
         Self::splat(self.x)
@@ -28,8 +28,8 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let hex = Hex::new(1, 2);
-    /// assert_eq!(hex.yy(), Hex::new(2, 2));
+    /// let point = Hex::new(1, 2);
+    /// assert_eq!(point.yy(), Hex::new(2, 2));
     /// ```
     pub const fn yy(self) -> Self {
         Self::splat(self.y)
@@ -45,8 +45,8 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let hex = Hex::new(1, 2);
-    /// assert_eq!(hex.zz(), Hex::new(-3, -3));
+    /// let point = Hex::new(1, 2);
+    /// assert_eq!(point.zz(), Hex::new(-3, -3));
     /// ```
     pub const fn zz(self) -> Self {
         Self::splat(self.z())
@@ -62,8 +62,8 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let hex = Hex::new(1, 2);
-    /// assert_eq!(hex.yx(), Hex::new(2, 1));
+    /// let point = Hex::new(1, 2);
+    /// assert_eq!(point.yx(), Hex::new(2, 1));
     /// ```
     pub const fn yx(self) -> Self {
         Self {
@@ -82,8 +82,8 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let hex = Hex::new(1, 2);
-    /// assert_eq!(hex.yz(), Hex::new(2, -3));
+    /// let point = Hex::new(1, 2);
+    /// assert_eq!(point.yz(), Hex::new(2, -3));
     /// ```
     pub const fn yz(self) -> Self {
         Self {
@@ -102,8 +102,8 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let hex = Hex::new(1, 2);
-    /// assert_eq!(hex.xz(), Hex::new(1, -3));
+    /// let point = Hex::new(1, 2);
+    /// assert_eq!(point.xz(), Hex::new(1, -3));
     /// ```
     pub const fn xz(self) -> Self {
         Self {
@@ -122,8 +122,8 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let hex = Hex::new(1, 2);
-    /// assert_eq!(hex.zx(), Hex::new(-3, 1));
+    /// let point = Hex::new(1, 2);
+    /// assert_eq!(point.zx(), Hex::new(-3, 1));
     /// ```
     pub const fn zx(self) -> Self {
         Self {
@@ -142,8 +142,8 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let hex = Hex::new(1, 2);
-    /// assert_eq!(hex.zy(), Hex::new(-3, 2));
+    /// let point = Hex::new(1, 2);
+    /// assert_eq!(point.zy(), Hex::new(-3, 2));
     /// ```
     pub const fn zy(self) -> Self {
         Self {

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -55,18 +55,18 @@ fn hex_length() {
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::cast_possible_wrap)]
 fn hex_avg_center() {
-    let hexes = [
+    let points = [
         Hex::ONE,
         Hex::new(5, -12),
         Hex::new(15, 2),
         Hex::new(-5, 24),
         Hex::new(-1, 17),
     ];
-    let mean = hexes.iter().sum::<Hex>() / hexes.len() as i32;
+    let mean = points.iter().sum::<Hex>() / points.len() as i32;
     let center = Hex::new(10, 12) / 2;
 
-    assert_eq!(hexes.into_iter().average(), mean);
-    assert_eq!(hexes.into_iter().center(), center);
+    assert_eq!(points.into_iter().average(), mean);
+    assert_eq!(points.into_iter().center(), center);
     assert_ne!(center, mean);
 
     for r in 0..30 {
@@ -122,12 +122,12 @@ fn int_division() {
 
     for x in 0..30 {
         for y in 0..30 {
-            let hex = Hex { x, y };
+            let p = Hex { x, y };
             for d in 1..30 {
-                let expected_len = hex.length() / d;
-                let res_int = hex / d;
-                let res_float = hex / d as f32;
-                let res_lerp = Hex::ZERO.lerp(hex, expected_len as f32 / hex.length() as f32);
+                let expected_len = p.length() / d;
+                let res_int = p / d;
+                let res_float = p / d as f32;
+                let res_lerp = Hex::ZERO.lerp(p, expected_len as f32 / p.length() as f32);
 
                 assert_eq!(res_int.length(), expected_len);
                 assert_eq!(res_int, res_float);
@@ -141,19 +141,19 @@ fn int_division() {
 fn hex_rem() {
     for x in 1..30 {
         for y in 1..30 {
-            let hex = Hex::new(x, y);
+            let p = Hex::new(x, y);
             for x2 in 1..30 {
                 for y2 in 1..30 {
                     // Int
                     let rhs = x2;
-                    let div = hex / rhs;
-                    let rem = hex % rhs;
-                    assert_eq!(div * rhs + rem, hex);
+                    let div = p / rhs;
+                    let rem = p % rhs;
+                    assert_eq!(div * rhs + rem, p);
                     // Hex
                     let rhs = Hex::new(x2, y2);
-                    let div = hex / rhs;
-                    let rem = hex % rhs;
-                    assert_eq!(div * rhs + rem, hex);
+                    let div = p / rhs;
+                    let rem = p % rhs;
+                    assert_eq!(div * rhs + rem, p);
                 }
             }
         }
@@ -237,52 +237,52 @@ fn rotation() {
 
 #[test]
 fn rotate_right() {
-    let hex = Hex::new(5, 0);
-    let new = hex.right();
+    let point = Hex::new(5, 0);
+    let new = point.right();
     assert_eq!(new, Hex::new(0, 5));
-    assert_eq!(hex.rotate_right(1), new);
+    assert_eq!(point.rotate_right(1), new);
     let new = new.right();
     assert_eq!(new, Hex::new(-5, 5));
-    assert_eq!(hex.rotate_right(2), new);
+    assert_eq!(point.rotate_right(2), new);
     let new = new.right();
     assert_eq!(new, Hex::new(-5, 0));
-    assert_eq!(hex.rotate_right(3), new);
+    assert_eq!(point.rotate_right(3), new);
     let new = new.right();
     assert_eq!(new, Hex::new(0, -5));
-    assert_eq!(hex.rotate_right(4), new);
+    assert_eq!(point.rotate_right(4), new);
     let new = new.right();
     assert_eq!(new, Hex::new(5, -5));
-    assert_eq!(hex.rotate_right(5), new);
+    assert_eq!(point.rotate_right(5), new);
     let new = new.right();
-    assert_eq!(new, hex);
-    assert_eq!(hex.rotate_right(6), new);
-    assert_eq!(hex.rotate_right(7), hex.rotate_right(1));
-    assert_eq!(hex.rotate_right(10), hex.rotate_right(4));
+    assert_eq!(new, point);
+    assert_eq!(point.rotate_right(6), new);
+    assert_eq!(point.rotate_right(7), point.rotate_right(1));
+    assert_eq!(point.rotate_right(10), point.rotate_right(4));
 }
 
 #[test]
 fn rotate_left() {
-    let hex = Hex::new(5, 0);
-    let new = hex.left();
+    let point = Hex::new(5, 0);
+    let new = point.left();
     assert_eq!(new, Hex::new(5, -5));
-    assert_eq!(hex.rotate_left(1), new);
+    assert_eq!(point.rotate_left(1), new);
     let new = new.left();
     assert_eq!(new, Hex::new(0, -5));
-    assert_eq!(hex.rotate_left(2), new);
+    assert_eq!(point.rotate_left(2), new);
     let new = new.left();
     assert_eq!(new, Hex::new(-5, 0));
-    assert_eq!(hex.rotate_left(3), new);
+    assert_eq!(point.rotate_left(3), new);
     let new = new.left();
     assert_eq!(new, Hex::new(-5, 5));
-    assert_eq!(hex.rotate_left(4), new);
+    assert_eq!(point.rotate_left(4), new);
     let new = new.left();
     assert_eq!(new, Hex::new(0, 5));
-    assert_eq!(hex.rotate_left(5), new);
+    assert_eq!(point.rotate_left(5), new);
     let new = new.left();
-    assert_eq!(new, hex);
-    assert_eq!(hex.rotate_left(6), new);
-    assert_eq!(hex.rotate_left(7), hex.rotate_left(1));
-    assert_eq!(hex.rotate_left(10), hex.rotate_left(4));
+    assert_eq!(new, point);
+    assert_eq!(point.rotate_left(6), new);
+    assert_eq!(point.rotate_left(7), point.rotate_left(1));
+    assert_eq!(point.rotate_left(10), point.rotate_left(4));
 }
 
 #[test]
@@ -377,8 +377,8 @@ fn range_count() {
 
 #[test]
 fn range() {
-    let hex = Hex::new(13, -54);
-    let mut range = hex.range(16);
+    let point = Hex::new(13, -54);
+    let mut range = point.range(16);
     assert_eq!(range.len(), Hex::range_count(16));
     assert_eq!(range.size_hint(), (range.len(), Some(range.len())));
     println!("{:#?}", range.size_hint());
@@ -393,16 +393,16 @@ fn range() {
 
 #[test]
 fn ring() {
-    let hex = Hex::ZERO;
-    assert_eq!(hex.ring(0), vec![hex]);
-    let expected = hex.all_neighbors().to_vec();
-    assert_eq!(hex.ring(1), expected);
+    let point = Hex::ZERO;
+    assert_eq!(point.ring(0), vec![point]);
+    let expected = point.all_neighbors().to_vec();
+    assert_eq!(point.ring(1), expected);
 
     let radius = 5;
-    let mut range: Vec<_> = hex.range(radius).collect();
-    let removed: Vec<_> = hex.range(radius - 1).collect();
+    let mut range: Vec<_> = point.range(radius).collect();
+    let removed: Vec<_> = point.range(radius - 1).collect();
     range.retain(|h| !removed.contains(h));
-    let ring = hex.ring(5);
+    let ring = point.ring(5);
     assert_eq!(ring.len(), range.len());
     for h in &ring {
         assert!(range.contains(h));
@@ -412,10 +412,10 @@ fn ring() {
 #[test]
 #[allow(clippy::cast_possible_truncation)]
 fn cached_rings() {
-    let hex = Hex::ZERO;
-    let cache = hex.cached_rings::<10>();
+    let point = Hex::ZERO;
+    let cache = point.cached_rings::<10>();
     for (r, ring) in cache.into_iter().enumerate() {
-        assert_eq!(ring, hex.ring(r as u32));
+        assert_eq!(ring, point.ring(r as u32));
     }
 }
 
@@ -430,17 +430,17 @@ fn ring_offset() {
 
 #[test]
 fn custom_ring() {
-    let hex = Hex::ZERO;
-    assert_eq!(hex.custom_ring(0, Direction::TopLeft, true), vec![hex]);
+    let point = Hex::ZERO;
+    assert_eq!(point.custom_ring(0, Direction::TopLeft, true), vec![point]);
 
     // clockwise
-    let mut expected = hex.ring(5);
+    let mut expected = point.ring(5);
     expected.reverse();
     expected.rotate_right(1);
-    assert_eq!(hex.custom_ring(5, Direction::TopRight, true), expected);
+    assert_eq!(point.custom_ring(5, Direction::TopRight, true), expected);
     // offsetted
-    let expected = hex.ring(5);
-    let ring = hex.custom_ring(5, Direction::BottomLeft, false);
+    let expected = point.ring(5);
+    let ring = point.custom_ring(5, Direction::BottomLeft, false);
     assert_eq!(expected.len(), ring.len());
     for h in &ring {
         assert!(expected.contains(h));
@@ -449,17 +449,17 @@ fn custom_ring() {
 
 #[test]
 fn ring_edge() {
-    let hex = Hex::new(-189, 35);
-    let edge = hex.ring_edge(48, DiagonalDirection::TopRight);
+    let point = Hex::new(-189, 35);
+    let edge = point.ring_edge(48, DiagonalDirection::TopRight);
     assert_eq!(edge.len(), edge.count());
     // empty
-    let edge = hex.ring_edge(0, DiagonalDirection::TopRight);
+    let edge = point.ring_edge(0, DiagonalDirection::TopRight);
     let len = edge.len();
     let edge: Vec<_> = edge.collect();
     assert_eq!(edge.len(), len);
-    assert_eq!(edge, vec![hex]);
+    assert_eq!(edge, vec![point]);
     // len 1
-    let edge = hex.ring_edge(1, DiagonalDirection::TopRight);
+    let edge = point.ring_edge(1, DiagonalDirection::TopRight);
     let len = edge.len();
     let edge: Vec<_> = edge.collect();
     assert_eq!(edge.len(), len);
@@ -469,13 +469,13 @@ fn ring_edge() {
 #[test]
 #[allow(clippy::cast_possible_truncation)]
 fn wedge() {
-    let hex = Hex::new(98, -123);
+    let point = Hex::new(98, -123);
     for dir in DiagonalDirection::ALL_DIRECTIONS {
         for range in 0..=30 {
-            let wedge: Vec<_> = hex.wedge(0..=range, dir).collect();
+            let wedge: Vec<_> = point.wedge(0..=range, dir).collect();
             assert_eq!(wedge.len() as u32, range * (range + 3) / 2 + 1);
             assert_eq!(wedge.len() as u32, Hex::wedge_count(range));
-            let full_wedge = hex.full_wedge(range, dir);
+            let full_wedge = point.full_wedge(range, dir);
             assert_eq!(full_wedge.len(), wedge.len());
         }
     }

--- a/src/hex_map.rs
+++ b/src/hex_map.rs
@@ -9,13 +9,13 @@ use crate::{Hex, HexBounds};
 /// ```rust
 /// # use hexx::*;
 ///
-/// let map = HexMap::new(10).with_center(Hex::new(1, 2));
+/// let map = HexMap::new(10).with_center(hex(1, 2));
 /// // Define a coordinate, even ouside of bounds
-/// let hex = Hex::new(100, 100);
-/// assert!(!map.bounds().is_in_bounds(hex));
+/// let point = Hex::new(100, 100);
+/// assert!(!map.bounds().is_in_bounds(point));
 /// // Retrieve the wrapped position in the map
-/// let wrapped_hex = map.wrapped_hex(hex);
-/// assert!(map.bounds().is_in_bounds(wrapped_hex));
+/// let wrapped_point = map.wrapped_hex(point);
+/// assert!(map.bounds().is_in_bounds(wrapped_point));
 /// ```
 ///
 /// [wraparound]: https://www.redblobgames.com/grids/hexagons/#wraparound

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -86,13 +86,13 @@ mod tests {
 
     #[test]
     fn flat_corners() {
-        let hex = Hex::new(0, 0);
+        let point = Hex::new(0, 0);
         let layout = HexLayout {
             orientation: HexOrientation::flat(),
             origin: Vec2::ZERO,
             hex_size: Vec2::new(10., 10.),
         };
-        let corners = layout.hex_corners(hex).map(Vec2::round);
+        let corners = layout.hex_corners(point).map(Vec2::round);
         assert_eq!(
             corners,
             [
@@ -108,13 +108,13 @@ mod tests {
 
     #[test]
     fn pointy_corners() {
-        let hex = Hex::new(0, 0);
+        let point = Hex::new(0, 0);
         let layout = HexLayout {
             orientation: HexOrientation::pointy(),
             origin: Vec2::ZERO,
             hex_size: Vec2::new(10., 10.),
         };
-        let corners = layout.hex_corners(hex).map(Vec2::round);
+        let corners = layout.hex_corners(point).map(Vec2::round);
         assert_eq!(
             corners,
             [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@
 //! use hexx::*;
 //!
 //! // Declare points in hexagonal spaces
-//! let point_a = Hex::new(10, -5);
-//! let point_b = Hex::new(-8, 15);
+//! let point_a = hex(10, -5); // Equivalent of `Hex::new(10, -5)`
+//! let point_b = hex(-8, 15);
 //! // Find distance between them
 //! let dist = point_a.unsigned_distance_to(point_b);
 //! // Compute a line between points
@@ -87,7 +87,7 @@
 //! let world_pos = Vec2::new(53.52, 189.28);
 //! let hex = layout.world_pos_to_hex(world_pos);
 //! // Get the world position of `hex`
-//! let hex = Hex::new(123, 45);
+//! let hex = hex(123, 45);
 //! let world_pos = layout.hex_to_world_pos(hex);
 //!```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,10 +85,10 @@
 //! };
 //! // Get the hex coordinate at the world position `world_pos`.
 //! let world_pos = Vec2::new(53.52, 189.28);
-//! let hex = layout.world_pos_to_hex(world_pos);
-//! // Get the world position of `hex`
-//! let hex = hex(123, 45);
-//! let world_pos = layout.hex_to_world_pos(hex);
+//! let point = layout.world_pos_to_hex(world_pos);
+//! // Get the world position of `point`
+//! let point = hex(123, 45);
+//! let world_pos = layout.hex_to_world_pos(point);
 //!```
 //!
 //! ## Usage in [Bevy](https://bevyengine.org/)

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -77,9 +77,9 @@ mod tests {
 
     #[test]
     fn hexagon_test() {
-        let hex = Hex::new(3, -987);
+        let point = Hex::new(3, -987);
         for range in 0..=30 {
-            let iter = hexagon(hex, range);
+            let iter = hexagon(point, range);
             assert_eq!(iter.len(), iter.count());
         }
     }


### PR DESCRIPTION
# Work done

Added two missing elements:
- A global `hex` constructor like `glam`'s `ivec2`
- A `Hex::from_array` method

Also removed `Debug` and `Hash` derives for spirv