### PR TITLE
repr C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Before: `Hex::new()`
   - Now: `hex()`
 * `Hex` won't derive `Debug` or `Hash` on spirv archs (#66)
+* Added `packed` feature to make `Hex` `repr(C)` (#67)
 
 ### Examples
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [".github"]
 
 [features]
 default = []
+packed = []
 # serde compatibility
 ser_de = ["serde", "glam/serde"]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/hexx.png?" alt="logo">
+  <img src="docs/hexx.png?" alt="Hexx">
 </p>
 
 [![workflow](https://github.com/ManevilleF/hexx/actions/workflows/rust.yml/badge.svg)](https://github.com/ManevilleF/hexx/actions/workflows/rust.yml)
@@ -37,6 +37,12 @@
  through the `ser_de` feature gate. To enable it add the following line to your `Cargo.toml`:
 
  - `hexx = { version = "0.5", features = ["ser_de"] }`
+
+ By default `Hex` uses rust classic memory layout, if you want to use `hexx` through the FFI or
+ have `Hex` be stored without any memory padding, the `packed` feature will make `Hex`
+ `repr(C)`. To enable this behaviour add the following line to your `Cargo.toml`:
+
+ - `hexx = { version = "0.5", features = ["packed"] }`
 
  ## Features
 

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -46,6 +46,7 @@ use std::cmp::{max, min};
 #[derive(Copy, Clone, Default, Eq, PartialEq)]
 #[cfg_attr(not(target_arch = "spirv"), derive(Debug, Hash))]
 #[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "packed", repr(C))]
 pub struct Hex {
     /// `x` axial coordinate (sometimes called `q` or `i`)
     pub x: i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,12 @@
 //!
 //! - `hexx = { version = "0.5", features = ["ser_de"] }`
 //!
+//! By default `Hex` uses rust classic memory layout, if you want to use `hexx` through the FFI or
+//! have `Hex` be stored without any memory padding, the `packed` feature will make `Hex`
+//! `repr(C)`. To enable this behaviour add the following line to your `Cargo.toml`:
+//!
+//! - `hexx = { version = "0.5", features = ["packed"] }`
+//!
 //! ## Features
 //!
 //! `hexx` provides the [`Hex`] coordinates with:


### PR DESCRIPTION
Added `packed` feature to make `Hex` `repr(C)` 