### PR TITLE
Rings return an iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,20 @@
 
 * Changed logo (#63)
 * Drop `itertools` dependency (#58)
-* Removed deprecated `Hex::directions_to` method (#58)
+* (**BREAKING**) Removed deprecated `Hex::directions_to` method (#58)
 * Added `MeshInfo::facing` utils method to rotate hex meshes (#65)
 * Added `hex` utils function to create an `Hex`, making it less boilerplate (#66):
   - Before: `Hex::new()`
   - Now: `hex()`
 * `Hex` won't derive `Debug` or `Hash` on spirv archs (#66)
 * Added `packed` feature to make `Hex` `repr(C)` (#67)
+
+### ExactSizeIterator
+
+* (**BREAKING**) `Hex::ring` now returns a `ExactSizeIterator` instead of a `Vec` (#68)
+* (**BREAKING**) `Hex::custom_ring` now returns a `ExactSizeIterator` instead of a `Vec` (#68)
+* (**BREAKING**) `Hex::rings` now returns an iterator of `ExactSizeIterator` instead of `Vec` (#68)
+* (**BREAKING**) `Hex::custom_rings` now returns an iterator of `ExactSizeIterator` instead of `Vec` (#68)
 
 ### Examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@
 
 * (**BREAKING**) `Hex::ring` now returns a `ExactSizeIterator` instead of a `Vec` (#68)
 * (**BREAKING**) `Hex::custom_ring` now returns a `ExactSizeIterator` instead of a `Vec` (#68)
-* (**BREAKING**) `Hex::rings` now returns an iterator of `ExactSizeIterator` instead of `Vec` (#68)
-* (**BREAKING**) `Hex::custom_rings` now returns an iterator of `ExactSizeIterator` instead of `Vec` (#68)
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
  // Compute a line between points
  let line: Vec<Hex> = point_a.line_to(point_b).collect();
  // Compute a ring from `point_a` containing `point_b`
- let ring: Vec<Hex> = point_a.ring(dist);
+ let ring: Vec<Hex> = point_a.ring(dist).collect();
  // Rotate `point_b` around `point_a` by 2 times 60 degrees clockwise
  let rotated = point_b.rotate_right_around(point_a, 2);
  // Find the direction between the two points

--- a/examples/3d_columns.rs
+++ b/examples/3d_columns.rs
@@ -113,7 +113,7 @@ fn animate_rings(
     if highlighted_hexes.ring > MAP_RADIUS {
         highlighted_hexes.ring = 0;
     }
-    highlighted_hexes.hexes = Hex::ZERO.ring(highlighted_hexes.ring);
+    highlighted_hexes.hexes = Hex::ZERO.ring(highlighted_hexes.ring).collect();
     // Draw a ring
     for h in &highlighted_hexes.hexes {
         if let Some(e) = map.entities.get(h) {

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -143,19 +143,19 @@ fn handle_input(
             // Draw a  line
             highlighted_hexes.line = Hex::ZERO.line_to(coord).collect();
             // Draw a ring
-            highlighted_hexes.ring = Hex::ZERO.ring(coord.ulength());
+            highlighted_hexes.ring = Hex::ZERO.ring(coord.ulength()).collect();
             // Draw an wedge
             highlighted_hexes.wedge = Hex::ZERO.wedge_to(coord).collect();
             // Draw a half ring
-            highlighted_hexes.half_ring = Hex::ZERO.ring(coord.ulength() / 2);
+            highlighted_hexes.half_ring = Hex::ZERO.ring(coord.ulength() / 2).collect();
             // Draw rotations
             highlighted_hexes.rotated = (1..6).map(|i| coord.rotate_right(i)).collect();
             // Draw an dual wedge
             highlighted_hexes.dir_wedge = Hex::ZERO.corner_wedge_to(coord / 2).collect();
             for (vec, mat) in [
-                (&highlighted_hexes.ring, &map.ring_material),
                 (&highlighted_hexes.wedge, &map.wedge_material),
                 (&highlighted_hexes.dir_wedge, &map.dir_wedge_material),
+                (&highlighted_hexes.ring, &map.ring_material),
                 (&highlighted_hexes.line, &map.line_material),
                 (&highlighted_hexes.half_ring, &map.half_ring_material),
                 (&highlighted_hexes.rotated, &map.selected_material),

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -834,7 +834,7 @@ impl Hex {
         ExactSizeHexIterator {
             iter: (-radius..=radius).flat_map(move |x| {
                 (max(-radius, -x - radius)..=min(radius, radius - x))
-                    .map(move |y| self + Self::new(x, y))
+                    .map(move |y| self.const_add(Self::new(x, y)))
             }),
             count: Self::range_count(range),
         }

--- a/src/hex/rings.rs
+++ b/src/hex/rings.rs
@@ -35,13 +35,10 @@ impl Hex {
             .flat_map(move |dir| std::iter::repeat(dir).take(range as usize))
             .scan(point, move |pos, dir| {
                 let next = *pos + dir;
-                if next == point {
-                    None
-                } else {
-                    *pos = next;
-                    Some(next)
-                }
-            });
+                *pos = next;
+                Some(next)
+            })
+            .take((range as usize * 6).saturating_sub(1));
         ExactSizeHexIterator {
             iter: std::iter::once(point).chain(iter),
             count: Self::ring_count(range),

--- a/src/hex/rings.rs
+++ b/src/hex/rings.rs
@@ -74,11 +74,8 @@ impl Hex {
     /// let rings: Vec<Vec<Hex>> = Hex::ZERO.rings(3..10).collect();
     /// assert_eq!(rings.len(), 7);
     /// ```
-    pub fn rings(
-        self,
-        range: impl Iterator<Item = u32>,
-    ) -> impl Iterator<Item = impl ExactSizeIterator<Item = Self>> {
-        range.map(move |r| self.ring(r))
+    pub fn rings(self, range: impl Iterator<Item = u32>) -> impl Iterator<Item = Vec<Self>> {
+        range.map(move |r| self.ring(r).collect())
     }
 
     /// Retrieves `range` [`Hex`] rings around `self` in a given `range`.
@@ -99,8 +96,8 @@ impl Hex {
         range: impl Iterator<Item = u32>,
         start_dir: Direction,
         clockwise: bool,
-    ) -> impl Iterator<Item = impl ExactSizeIterator<Item = Self>> {
-        range.map(move |r| self.custom_ring(r, start_dir, clockwise))
+    ) -> impl Iterator<Item = Vec<Self>> {
+        range.map(move |r| self.custom_ring(r, start_dir, clockwise).collect())
     }
 
     #[must_use]

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -410,18 +410,6 @@ fn ring() {
 }
 
 #[test]
-fn naive_ring() {
-    let point = Hex::ZERO;
-
-    for range in 0..=30 {
-        let naive = point.naive_ring(range);
-        let ring = point.ring(range);
-        assert_eq!(naive.len(), ring.len());
-        assert_eq!(naive.len(), naive.count());
-    }
-}
-
-#[test]
 #[allow(clippy::cast_possible_truncation)]
 fn cached_rings() {
     let point = Hex::ZERO;

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -394,9 +394,9 @@ fn range() {
 #[test]
 fn ring() {
     let point = Hex::ZERO;
-    assert_eq!(point.ring(0), vec![point]);
+    assert_eq!(point.ring(0).collect::<Vec<_>>(), vec![point]);
     let expected = point.all_neighbors().to_vec();
-    assert_eq!(point.ring(1), expected);
+    assert_eq!(point.ring(1).collect::<Vec<_>>(), expected);
 
     let radius = 5;
     let mut range: Vec<_> = point.range(radius).collect();
@@ -404,8 +404,20 @@ fn ring() {
     range.retain(|h| !removed.contains(h));
     let ring = point.ring(5);
     assert_eq!(ring.len(), range.len());
-    for h in &ring {
-        assert!(range.contains(h));
+    for h in ring {
+        assert!(range.contains(&h));
+    }
+}
+
+#[test]
+fn naive_ring() {
+    let point = Hex::ZERO;
+
+    for range in 0..=30 {
+        let naive = point.naive_ring(range);
+        let ring = point.ring(range);
+        assert_eq!(naive.len(), ring.len());
+        assert_eq!(naive.len(), naive.count());
     }
 }
 
@@ -415,7 +427,8 @@ fn cached_rings() {
     let point = Hex::ZERO;
     let cache = point.cached_rings::<10>();
     for (r, ring) in cache.into_iter().enumerate() {
-        assert_eq!(ring, point.ring(r as u32));
+        let expected: Vec<_> = point.ring(r as u32).collect();
+        assert_eq!(ring, expected);
     }
 }
 
@@ -424,26 +437,36 @@ fn ring_offset() {
     let zero = Hex::ZERO;
     let target = Hex::new(14, 7);
 
-    let expected: Vec<_> = zero.ring(10).into_iter().map(|h| h + target).collect();
-    assert_eq!(target.ring(10), expected);
+    let expected: Vec<_> = zero.ring(10).map(|h| h + target).collect();
+    assert_eq!(target.ring(10).collect::<Vec<_>>(), expected);
 }
 
 #[test]
 fn custom_ring() {
     let point = Hex::ZERO;
-    assert_eq!(point.custom_ring(0, Direction::TopLeft, true), vec![point]);
+    assert_eq!(
+        point
+            .custom_ring(0, Direction::TopLeft, true)
+            .collect::<Vec<_>>(),
+        vec![point]
+    );
 
     // clockwise
-    let mut expected = point.ring(5);
+    let mut expected: Vec<_> = point.ring(5).collect();
     expected.reverse();
     expected.rotate_right(1);
-    assert_eq!(point.custom_ring(5, Direction::TopRight, true), expected);
+    assert_eq!(
+        point
+            .custom_ring(5, Direction::TopRight, true)
+            .collect::<Vec<_>>(),
+        expected
+    );
     // offsetted
-    let expected = point.ring(5);
+    let expected: Vec<_> = point.ring(5).collect();
     let ring = point.custom_ring(5, Direction::BottomLeft, false);
     assert_eq!(expected.len(), ring.len());
-    for h in &ring {
-        assert!(expected.contains(h));
+    for h in ring {
+        assert!(expected.contains(&h));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! // Compute a line between points
 //! let line: Vec<Hex> = point_a.line_to(point_b).collect();
 //! // Compute a ring from `point_a` containing `point_b`
-//! let ring: Vec<Hex> = point_a.ring(dist);
+//! let ring: Vec<Hex> = point_a.ring(dist).collect();
 //! // Rotate `point_b` around `point_a` by 2 times 60 degrees clockwise
 //! let rotated = point_b.rotate_right_around(point_a, 2);
 //! // Find the direction between the two points


### PR DESCRIPTION
# Work done

* `Hex::ring` now returns a `ExactSizeIterator` instead of a `Vec`
* `Hex::custom_ring` now returns a `ExactSizeIterator` instead of a `Vec`
* Fixed `Hex::ring_count` returning 0 on radius == 0 
