### PR TITLE
Rename rotation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - `directional_fov` directional 120 degrees field of view (`Direction`)
 * Added field of movement algorithm in `algorithms`:
   - `field_of_movement` provides the available range of field of movement given a `budget` of movement and a movement `cost`
+* Renamed rotation functions to follow `cw`/`ccw` terminology (old versions deprecated)
 
 ### Directions to
 

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -149,7 +149,7 @@ fn handle_input(
             // Draw a half ring
             highlighted_hexes.half_ring = Hex::ZERO.ring(coord.ulength() / 2).collect();
             // Draw rotations
-            highlighted_hexes.rotated = (1..6).map(|i| coord.rotate_right(i)).collect();
+            highlighted_hexes.rotated = (1..6).map(|i| coord.rotate_cw(i)).collect();
             // Draw an dual wedge
             highlighted_hexes.dir_wedge = Hex::ZERO.corner_wedge_to(coord / 2).collect();
             for (vec, mat) in [

--- a/src/algorithms/fov.rs
+++ b/src/algorithms/fov.rs
@@ -58,7 +58,7 @@ pub fn directional_fov(
     direction: Direction,
     blocking: impl Fn(Hex) -> bool,
 ) -> HashSet<Hex> {
-    let [a, b] = [direction.diagonal_left(), direction.diagonal_right()];
+    let [a, b] = [direction.diagonal_ccw(), direction.diagonal_cw()];
     coord
         .ring(range)
         .filter(|h| {

--- a/src/direction/diagonal_direction.rs
+++ b/src/direction/diagonal_direction.rs
@@ -232,7 +232,7 @@ impl DiagonalDirection {
         }
     }
 
-    #[deprecated = "Use DiagonalDirection::cw"]
+    #[deprecated(since = "0.6.0", note = "Use DiagonalDirection::clockwise")]
     #[inline]
     #[must_use]
     /// Returns the next direction in clockwise order
@@ -255,7 +255,7 @@ impl DiagonalDirection {
         }
     }
 
-    #[deprecated = "Use DiagonalDirection::ccw"]
+    #[deprecated(since = "0.6.0", note = "Use DiagonalDirection::counter_clockwise")]
     #[inline]
     #[must_use]
     /// Returns the next direction in counter clockwise order
@@ -278,7 +278,7 @@ impl DiagonalDirection {
         }
     }
 
-    #[deprecated = "Use DiagonalDirection::rotate_ccw"]
+    #[deprecated(since = "0.6.0", note = "Use DiagonalDirection::rotate_ccw")]
     #[inline]
     #[must_use]
     /// Rotates `self` counter clockwise by `offset` amount.
@@ -314,7 +314,7 @@ impl DiagonalDirection {
         }
     }
 
-    #[deprecated = "Use DiagonalDirection::rotate_cw"]
+    #[deprecated(since = "0.6.0", note = "Use DiagonalDirection::rotate_cw")]
     #[inline]
     #[must_use]
     /// Rotates `self` clockwise by `offset` amount.
@@ -411,7 +411,7 @@ impl DiagonalDirection {
         self.angle_pointy() - orientation.angle_offset
     }
 
-    #[deprecated = "Use DiagonalDirection::direction_ccw"]
+    #[deprecated(since = "0.6.0", note = "Use DiagonalDirection::direction_ccw")]
     #[inline]
     #[must_use]
     /// Computes the counter clockwise [`Direction`] neighbor of `self`.
@@ -449,7 +449,7 @@ impl DiagonalDirection {
         }
     }
 
-    #[deprecated = "Use DiagonalDirection::direction_cw"]
+    #[deprecated(since = "0.6.0", note = "Use DiagonalDirection::direction_cw")]
     #[inline]
     #[must_use]
     /// Computes the clockwise [`Direction`] neighbor of `self`.

--- a/src/direction/diagonal_direction.rs
+++ b/src/direction/diagonal_direction.rs
@@ -22,10 +22,10 @@ use crate::{Direction, HexOrientation};
 ///
 /// Directions can be:
 ///  - rotated *clockwise* with:
-///     - [`Self::right`] and [`Self::rotate_right`]
+///     - [`Self::clockwise`] and [`Self::rotate_cw`]
 ///     - The shift right `>>` operator
 ///  - rotated *counter clockwise* with:
-///     - [`Self::left`] and [`Self::rotate_left`]
+///     - [`Self::counter_clockwise`] and [`Self::rotate_ccw`]
 ///     - The shift left `<<` operator
 ///  - negated using the minus `-` operator
 ///  - multiplied by an `i32`, returning a [`Hex`](crate::Hex) vector
@@ -232,11 +232,19 @@ impl DiagonalDirection {
         }
     }
 
+    #[deprecated = "Use DiagonalDirection::cw"]
     #[inline]
     #[must_use]
-    #[doc(alias = "clockwise")]
     /// Returns the next direction in clockwise order
     pub const fn right(self) -> Self {
+        self.clockwise()
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "cw")]
+    /// Returns the next direction in clockwise order
+    pub const fn clockwise(self) -> Self {
         match self {
             Self::Right => Self::BottomRight,
             Self::TopRight => Self::Right,
@@ -247,11 +255,19 @@ impl DiagonalDirection {
         }
     }
 
+    #[deprecated = "Use DiagonalDirection::ccw"]
     #[inline]
     #[must_use]
-    #[doc(alias = "counterclockwise")]
     /// Returns the next direction in counter clockwise order
     pub const fn left(self) -> Self {
+        self.counter_clockwise()
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "ccw")]
+    /// Returns the next direction in counter clockwise order
+    pub const fn counter_clockwise(self) -> Self {
         match self {
             Self::Right => Self::TopRight,
             Self::TopRight => Self::TopLeft,
@@ -262,6 +278,7 @@ impl DiagonalDirection {
         }
     }
 
+    #[deprecated = "Use DiagonalDirection::rotate_ccw"]
     #[inline]
     #[must_use]
     /// Rotates `self` counter clockwise by `offset` amount.
@@ -273,16 +290,31 @@ impl DiagonalDirection {
     /// assert_eq!(Direction::Top, Direction::Top.rotate_left(6));
     /// ```
     pub const fn rotate_left(self, offset: usize) -> Self {
+        self.rotate_ccw(offset)
+    }
+
+    #[inline]
+    #[must_use]
+    /// Rotates `self` counter clockwise by `offset` amount.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// assert_eq!(Direction::Top, Direction::Top.rotate_ccw(6));
+    /// ```
+    pub const fn rotate_ccw(self, offset: usize) -> Self {
         match offset % 6 {
-            1 => self.left(),
-            2 => self.left().left(),
+            1 => self.counter_clockwise(),
+            2 => self.counter_clockwise().counter_clockwise(),
             3 => self.const_neg(),
-            4 => self.right().right(),
-            5 => self.right(),
+            4 => self.clockwise().clockwise(),
+            5 => self.clockwise(),
             _ => self,
         }
     }
 
+    #[deprecated = "Use DiagonalDirection::rotate_cw"]
     #[inline]
     #[must_use]
     /// Rotates `self` clockwise by `offset` amount.
@@ -294,12 +326,26 @@ impl DiagonalDirection {
     /// assert_eq!(Direction::Top, Direction::Top.rotate_right(6));
     /// ```
     pub const fn rotate_right(self, offset: usize) -> Self {
+        self.rotate_cw(offset)
+    }
+
+    #[inline]
+    #[must_use]
+    /// Rotates `self` clockwise by `offset` amount.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// assert_eq!(Direction::Top, Direction::Top.rotate_ccw(6));
+    /// ```
+    pub const fn rotate_cw(self, offset: usize) -> Self {
         match offset % 6 {
-            1 => self.right(),
-            2 => self.right().right(),
+            1 => self.clockwise(),
+            2 => self.clockwise().clockwise(),
             3 => self.const_neg(),
-            4 => self.left().left(),
-            5 => self.left(),
+            4 => self.counter_clockwise().counter_clockwise(),
+            5 => self.counter_clockwise(),
             _ => self,
         }
     }
@@ -365,6 +411,7 @@ impl DiagonalDirection {
         self.angle_pointy() - orientation.angle_offset
     }
 
+    #[deprecated = "Use DiagonalDirection::direction_ccw"]
     #[inline]
     #[must_use]
     /// Computes the counter clockwise [`Direction`] neighbor of `self`.
@@ -377,6 +424,21 @@ impl DiagonalDirection {
     /// assert_eq!(dir, Direction::TopRight);
     /// ```
     pub const fn direction_left(self) -> Direction {
+        self.direction_ccw()
+    }
+
+    #[inline]
+    #[must_use]
+    /// Computes the counter clockwise [`Direction`] neighbor of `self`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let dir = DiagonalDirection::Right.direction_ccw();
+    /// assert_eq!(dir, Direction::TopRight);
+    /// ```
+    pub const fn direction_ccw(self) -> Direction {
         match self {
             Self::Right => Direction::TopRight,
             Self::TopRight => Direction::Top,
@@ -387,6 +449,7 @@ impl DiagonalDirection {
         }
     }
 
+    #[deprecated = "Use DiagonalDirection::direction_cw"]
     #[inline]
     #[must_use]
     /// Computes the clockwise [`Direction`] neighbor of `self`.
@@ -399,6 +462,21 @@ impl DiagonalDirection {
     /// assert_eq!(dir, Direction::BottomRight);
     /// ```
     pub const fn direction_right(self) -> Direction {
+        self.direction_cw()
+    }
+
+    #[inline]
+    #[must_use]
+    /// Computes the clockwise [`Direction`] neighbor of `self`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let dir = DiagonalDirection::Right.direction_cw();
+    /// assert_eq!(dir, Direction::BottomRight);
+    /// ```
+    pub const fn direction_cw(self) -> Direction {
         match self {
             Self::Right => Direction::BottomRight,
             Self::TopRight => Direction::TopRight,

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -25,10 +25,10 @@ use crate::{DiagonalDirection, HexOrientation};
 ///
 /// Directions can be:
 ///  - rotated *clockwise* with:
-///     - [`Self::right`] and [`Self::rotate_right`]
+///     - [`Self::clockwise`] and [`Self::rotate_cw`]
 ///     - The shift right `>>` operator
 ///  - rotated *counter clockwise* with:
-///     - [`Self::left`] and [`Self::rotate_left`]
+///     - [`Self::counter_clockwise`] and [`Self::rotate_ccw`]
 ///     - The shift left `<<` operator
 ///  - negated using the minus `-` operator
 ///  - multiplied by an `i32`, returning a [`Hex`](crate::Hex) vector
@@ -235,11 +235,19 @@ impl Direction {
         }
     }
 
+    #[deprecated = "Use Direction::clockwise"]
     #[inline]
     #[must_use]
-    #[doc(alias = "clockwise")]
     /// Returns the next direction in clockwise order
     pub const fn right(self) -> Self {
+        self.clockwise()
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "cw")]
+    /// Returns the next direction in clockwise order
+    pub const fn clockwise(self) -> Self {
         match self {
             Self::TopRight => Self::BottomRight,
             Self::Top => Self::TopRight,
@@ -250,11 +258,19 @@ impl Direction {
         }
     }
 
+    #[deprecated = "Use Direction::ccw"]
     #[inline]
     #[must_use]
-    #[doc(alias = "counterclockwise")]
     /// Returns the next direction in counter clockwise order
     pub const fn left(self) -> Self {
+        self.counter_clockwise()
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "ccw")]
+    /// Returns the next direction in counter clockwise order
+    pub const fn counter_clockwise(self) -> Self {
         match self {
             Self::TopRight => Self::Top,
             Self::Top => Self::TopLeft,
@@ -265,6 +281,7 @@ impl Direction {
         }
     }
 
+    #[deprecated = "Use Direction::rotate_ccw"]
     #[inline]
     #[must_use]
     /// Rotates `self` counter clockwise by `offset` amount.
@@ -273,17 +290,46 @@ impl Direction {
     ///
     /// ```rust
     /// # use hexx::*;
-    /// assert_eq!(DiagonalDirection::Right, DiagonalDirection::Right.rotate_left(6));
+    /// assert_eq!(Direction::Top, Direction::Top.rotate_left(6));
     /// ```
     pub const fn rotate_left(self, offset: usize) -> Self {
+        self.rotate_ccw(offset)
+    }
+
+    #[inline]
+    #[must_use]
+    /// Rotates `self` counter clockwise by `offset` amount.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// assert_eq!(Direction::Top, Direction::Top.rotate_ccw(6));
+    /// ```
+    pub const fn rotate_ccw(self, offset: usize) -> Self {
         match offset % 6 {
-            1 => self.left(),
-            2 => self.left().left(),
+            1 => self.counter_clockwise(),
+            2 => self.counter_clockwise().counter_clockwise(),
             3 => self.const_neg(),
-            4 => self.right().right(),
-            5 => self.right(),
+            4 => self.clockwise().clockwise(),
+            5 => self.clockwise(),
             _ => self,
         }
+    }
+
+    #[deprecated = "Use Direction::rotate_cw"]
+    #[inline]
+    #[must_use]
+    /// Rotates `self` clockwise by `offset` amount.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// assert_eq!(Direction::Top, Direction::Top.rotate_right(6));
+    /// ```
+    pub const fn rotate_right(self, offset: usize) -> Self {
+        self.rotate_cw(offset)
     }
 
     #[inline]
@@ -294,15 +340,15 @@ impl Direction {
     ///
     /// ```rust
     /// # use hexx::*;
-    /// assert_eq!(DiagonalDirection::Right, DiagonalDirection::Right.rotate_right(6));
+    /// assert_eq!(Direction::Top, Direction::Top.rotate_cw(6));
     /// ```
-    pub const fn rotate_right(self, offset: usize) -> Self {
+    pub const fn rotate_cw(self, offset: usize) -> Self {
         match offset % 6 {
-            1 => self.right(),
-            2 => self.right().right(),
+            1 => self.clockwise(),
+            2 => self.clockwise().clockwise(),
             3 => self.const_neg(),
-            4 => self.left().left(),
-            5 => self.left(),
+            4 => self.counter_clockwise().counter_clockwise(),
+            5 => self.counter_clockwise(),
             _ => self,
         }
     }
@@ -368,6 +414,7 @@ impl Direction {
         self.angle_pointy() - orientation.angle_offset
     }
 
+    #[deprecated = "Use Direction::diagonal_ccw"]
     #[inline]
     #[must_use]
     /// Computes the counter clockwise [`DiagonalDirection`] neighbor of self.
@@ -380,6 +427,21 @@ impl Direction {
     /// assert_eq!(diagonal, DiagonalDirection::TopLeft);
     /// ```
     pub const fn diagonal_left(self) -> DiagonalDirection {
+        self.diagonal_ccw()
+    }
+
+    #[inline]
+    #[must_use]
+    /// Computes the counter clockwise [`DiagonalDirection`] neighbor of self.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let diagonal = Direction::Top.diagonal_ccw();
+    /// assert_eq!(diagonal, DiagonalDirection::TopLeft);
+    /// ```
+    pub const fn diagonal_ccw(self) -> DiagonalDirection {
         match self {
             Self::TopRight => DiagonalDirection::TopRight,
             Self::Top => DiagonalDirection::TopLeft,
@@ -390,6 +452,7 @@ impl Direction {
         }
     }
 
+    #[deprecated = "Use Direction::diagonal_cw"]
     #[inline]
     #[must_use]
     /// Computes the clockwise [`DiagonalDirection`] neighbor of self.
@@ -402,6 +465,21 @@ impl Direction {
     /// assert_eq!(diagonal, DiagonalDirection::TopRight);
     /// ```
     pub const fn diagonal_right(self) -> DiagonalDirection {
+        self.diagonal_cw()
+    }
+
+    #[inline]
+    #[must_use]
+    /// Computes the clockwise [`DiagonalDirection`] neighbor of self.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let diagonal = Direction::Top.diagonal_cw();
+    /// assert_eq!(diagonal, DiagonalDirection::TopRight);
+    /// ```
+    pub const fn diagonal_cw(self) -> DiagonalDirection {
         match self {
             Self::TopRight => DiagonalDirection::Right,
             Self::Top => DiagonalDirection::TopRight,

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -235,7 +235,7 @@ impl Direction {
         }
     }
 
-    #[deprecated = "Use Direction::clockwise"]
+    #[deprecated(since = "0.6.0", note = "Use Direction::clockwise")]
     #[inline]
     #[must_use]
     /// Returns the next direction in clockwise order
@@ -258,7 +258,7 @@ impl Direction {
         }
     }
 
-    #[deprecated = "Use Direction::ccw"]
+    #[deprecated(since = "0.6.0", note = "Use Direction::ccw")]
     #[inline]
     #[must_use]
     /// Returns the next direction in counter clockwise order
@@ -281,7 +281,7 @@ impl Direction {
         }
     }
 
-    #[deprecated = "Use Direction::rotate_ccw"]
+    #[deprecated(since = "0.6.0", note = "Use Direction::rotate_ccw")]
     #[inline]
     #[must_use]
     /// Rotates `self` counter clockwise by `offset` amount.
@@ -317,7 +317,7 @@ impl Direction {
         }
     }
 
-    #[deprecated = "Use Direction::rotate_cw"]
+    #[deprecated(since = "0.6.0", note = "Use Direction::rotate_cw")]
     #[inline]
     #[must_use]
     /// Rotates `self` clockwise by `offset` amount.
@@ -414,7 +414,7 @@ impl Direction {
         self.angle_pointy() - orientation.angle_offset
     }
 
-    #[deprecated = "Use Direction::diagonal_ccw"]
+    #[deprecated(since = "0.6.0", note = "Use Direction::diagonal_ccw")]
     #[inline]
     #[must_use]
     /// Computes the counter clockwise [`DiagonalDirection`] neighbor of self.
@@ -452,7 +452,7 @@ impl Direction {
         }
     }
 
-    #[deprecated = "Use Direction::diagonal_cw"]
+    #[deprecated(since = "0.6.0", note = "Use Direction::diagonal_cw")]
     #[inline]
     #[must_use]
     /// Computes the clockwise [`DiagonalDirection`] neighbor of self.

--- a/src/direction/impls.rs
+++ b/src/direction/impls.rs
@@ -22,7 +22,7 @@ impl Shr<usize> for Direction {
     type Output = Self;
 
     fn shr(self, rhs: usize) -> Self::Output {
-        self.rotate_right(rhs)
+        self.rotate_cw(rhs)
     }
 }
 
@@ -30,7 +30,7 @@ impl Shr<usize> for DiagonalDirection {
     type Output = Self;
 
     fn shr(self, rhs: usize) -> Self::Output {
-        self.rotate_right(rhs)
+        self.rotate_cw(rhs)
     }
 }
 
@@ -38,7 +38,7 @@ impl Shl<usize> for Direction {
     type Output = Self;
 
     fn shl(self, rhs: usize) -> Self::Output {
-        self.rotate_left(rhs)
+        self.rotate_ccw(rhs)
     }
 }
 
@@ -46,7 +46,7 @@ impl Shl<usize> for DiagonalDirection {
     type Output = Self;
 
     fn shl(self, rhs: usize) -> Self::Output {
-        self.rotate_left(rhs)
+        self.rotate_ccw(rhs)
     }
 }
 

--- a/src/direction/tests.rs
+++ b/src/direction/tests.rs
@@ -10,24 +10,27 @@ mod hex_directions {
     use super::*;
 
     #[test]
-    fn rotate_left_right() {
+    fn rotate_ccw_cw() {
         for direction in Direction::ALL_DIRECTIONS {
-            assert_eq!(direction, direction.rotate_right(6));
-            assert_eq!(direction, direction.rotate_right(12));
-            assert_eq!(direction, direction.rotate_right(1).rotate_left(1));
-            assert_eq!(direction, direction.rotate_left(1).rotate_right(1));
-            assert_eq!(direction.left(), direction.rotate_left(1));
-            assert_eq!(direction.left().left(), direction.rotate_left(2));
-            assert_eq!(direction.right(), direction.rotate_right(1));
-            assert_eq!(direction.right().right(), direction.rotate_right(2));
+            assert_eq!(direction, direction.rotate_cw(6));
+            assert_eq!(direction, direction.rotate_cw(12));
+            assert_eq!(direction, direction.rotate_cw(1).rotate_ccw(1));
+            assert_eq!(direction, direction.rotate_ccw(1).rotate_cw(1));
+            assert_eq!(direction.counter_clockwise(), direction.rotate_ccw(1));
+            assert_eq!(
+                direction.counter_clockwise().counter_clockwise(),
+                direction.rotate_ccw(2)
+            );
+            assert_eq!(direction.clockwise(), direction.rotate_cw(1));
+            assert_eq!(direction.clockwise().clockwise(), direction.rotate_cw(2));
         }
     }
 
     #[test]
     fn rotations_reverse_each_other() {
         for direction in Direction::ALL_DIRECTIONS {
-            assert_eq!(direction, direction.left().right());
-            assert_eq!(direction, direction.right().left());
+            assert_eq!(direction, direction.counter_clockwise().clockwise());
+            assert_eq!(direction, direction.clockwise().counter_clockwise());
         }
     }
 
@@ -38,8 +41,8 @@ mod hex_directions {
             let mut counter_clockwise_dir = direction;
 
             for _ in 0..6 {
-                clockwise_dir = clockwise_dir.left();
-                counter_clockwise_dir = counter_clockwise_dir.right();
+                clockwise_dir = clockwise_dir.counter_clockwise();
+                counter_clockwise_dir = counter_clockwise_dir.clockwise();
             }
 
             assert_eq!(direction, clockwise_dir);
@@ -114,8 +117,8 @@ mod hex_directions {
     #[test]
     fn diagonal_neighbors() {
         for dir in Direction::ALL_DIRECTIONS {
-            assert_eq!(dir.diagonal_left().direction_right(), dir);
-            assert_eq!(dir.diagonal_right().direction_left(), dir);
+            assert_eq!(dir.diagonal_ccw().direction_cw(), dir);
+            assert_eq!(dir.diagonal_cw().direction_ccw(), dir);
         }
     }
 }
@@ -126,15 +129,15 @@ mod diagonal_direction {
     #[test]
     fn dir_neighbors() {
         for dir in DiagonalDirection::ALL_DIRECTIONS {
-            assert_eq!(dir.direction_left().diagonal_right(), dir);
-            assert_eq!(dir.direction_right().diagonal_left(), dir);
+            assert_eq!(dir.direction_ccw().diagonal_cw(), dir);
+            assert_eq!(dir.direction_cw().diagonal_ccw(), dir);
         }
     }
 
     #[test]
     fn flat_angles_rad() {
         for dir in DiagonalDirection::ALL_DIRECTIONS {
-            let expected = dir.direction_left().angle_flat() - PI / 6.0;
+            let expected = dir.direction_ccw().angle_flat() - PI / 6.0;
             assert!(dir.angle_flat() - expected <= EPSILON);
         }
     }
@@ -142,7 +145,7 @@ mod diagonal_direction {
     #[test]
     fn pointy_angles_rad() {
         for dir in DiagonalDirection::ALL_DIRECTIONS {
-            let expected = dir.direction_left().angle_pointy() - PI / 6.0;
+            let expected = dir.direction_ccw().angle_pointy() - PI / 6.0;
             assert!(dir.angle_pointy() - expected <= EPSILON);
         }
     }
@@ -150,7 +153,7 @@ mod diagonal_direction {
     #[test]
     fn flat_angles_degrees() {
         for dir in DiagonalDirection::ALL_DIRECTIONS {
-            let expected = dir.direction_left().angle_flat_degrees() - 30.0;
+            let expected = dir.direction_ccw().angle_flat_degrees() - 30.0;
             assert!(dir.angle_flat_degrees() - expected <= EPSILON);
         }
     }
@@ -158,7 +161,7 @@ mod diagonal_direction {
     #[test]
     fn pointy_angles_degrees() {
         for dir in DiagonalDirection::ALL_DIRECTIONS {
-            let expected = dir.direction_left().angle_pointy_degrees() - 30.0;
+            let expected = dir.direction_ccw().angle_pointy_degrees() - 30.0;
             assert!(dir.angle_pointy_degrees() - expected <= EPSILON);
         }
     }

--- a/src/direction/way.rs
+++ b/src/direction/way.rs
@@ -6,7 +6,7 @@ use crate::{DiagonalDirection, Direction};
 ///
 /// # Comparison
 ///
-/// to compare it with its inner [`Direction`] or [`DiagonalDirection`] you can use
+/// To compare it with its inner [`Direction`] or [`DiagonalDirection`] you can use
 /// `Self::contains` or the [`PartialEq`] implementation:
 ///
 /// ```rust
@@ -33,8 +33,12 @@ pub enum DirectionWay<T> {
 }
 
 pub trait Way: Copy + Neg<Output = Self> {
+    #[deprecated = "Use ccw"]
     fn left(self) -> Self;
+    fn ccw(self) -> Self;
+    #[deprecated = "Use cw"]
     fn right(self) -> Self;
+    fn cw(self) -> Self;
 }
 
 impl<T: PartialEq> PartialEq<T> for DirectionWay<T> {
@@ -72,10 +76,10 @@ impl<T: Way> DirectionWay<T> {
     #[inline]
     pub(crate) fn way_from(is_neg: bool, eq_left: bool, eq_right: bool, dir: T) -> Self {
         match [is_neg, eq_left, eq_right] {
-            [false, true, _] => Self::Tie([dir, dir.left()]),
-            [true, true, _] => Self::Tie([-dir, (-dir).left()]),
-            [false, _, true] => Self::Tie([dir, dir.right()]),
-            [true, _, true] => Self::Tie([-dir, (-dir).right()]),
+            [false, true, _] => Self::Tie([dir, dir.ccw()]),
+            [true, true, _] => Self::Tie([-dir, (-dir).ccw()]),
+            [false, _, true] => Self::Tie([dir, dir.cw()]),
+            [true, _, true] => Self::Tie([-dir, (-dir).cw()]),
             [true, _, _] => Self::Single(-dir),
             _ => Self::Single(dir),
         }
@@ -98,20 +102,36 @@ impl<T> From<[T; 2]> for DirectionWay<T> {
 
 impl Way for Direction {
     fn left(self) -> Self {
-        self.left()
+        self.counter_clockwise()
+    }
+
+    fn ccw(self) -> Self {
+        self.counter_clockwise()
     }
 
     fn right(self) -> Self {
-        self.right()
+        self.clockwise()
+    }
+
+    fn cw(self) -> Self {
+        self.clockwise()
     }
 }
 
 impl Way for DiagonalDirection {
     fn left(self) -> Self {
-        self.left()
+        self.counter_clockwise()
+    }
+
+    fn ccw(self) -> Self {
+        self.counter_clockwise()
     }
 
     fn right(self) -> Self {
-        self.right()
+        self.clockwise()
+    }
+
+    fn cw(self) -> Self {
+        self.clockwise()
     }
 }

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -714,7 +714,7 @@ impl Hex {
         Self::DIAGONAL_COORDS.map(|n| self + n)
     }
 
-    #[deprecated = "Use Hex::counter_clockwise"]
+    #[deprecated(since = "0.6.0", note = "Use Hex::counter_clockwise")]
     #[inline]
     #[must_use]
     /// Rotates `self` around [`Hex::ZERO`] counter clockwise (by -60 degrees)
@@ -748,7 +748,7 @@ impl Hex {
         Self::new(-self.z(), -self.x)
     }
 
-    #[deprecated = "Use Hex::ccw_around"]
+    #[deprecated(since = "0.6.0", note = "Use Hex::ccw_around")]
     #[inline]
     #[must_use]
     /// Rotates `self` around `center` counter clockwise (by -60 degrees)
@@ -763,7 +763,7 @@ impl Hex {
         self.const_sub(center).counter_clockwise().const_add(center)
     }
 
-    #[deprecated = "Use Hex::rotate_ccw"]
+    #[deprecated(since = "0.6.0", note = "Use Hex::rotate_ccw")]
     #[inline]
     #[must_use]
     /// Rotates `self` around [`Hex::ZERO`] counter clockwise by `m` (by `-60 * m` degrees)
@@ -785,7 +785,7 @@ impl Hex {
         }
     }
 
-    #[deprecated = "Use Hex::rotate_ccw_around"]
+    #[deprecated(since = "0.6.0", note = "Use Hex::rotate_ccw_around")]
     #[inline]
     #[must_use]
     /// Rotates `self` around `center` counter clockwise by `m` (by `-60 * m` degrees)
@@ -800,7 +800,7 @@ impl Hex {
         self.const_sub(center).rotate_ccw(m).const_add(center)
     }
 
-    #[deprecated = "Use Hex::clockwise"]
+    #[deprecated(since = "0.6.0", note = "Use Hex::clockwise")]
     #[inline]
     #[must_use]
     /// Rotates `self` around [`Hex::ZERO`] clockwise (by 60 degrees)
@@ -834,7 +834,7 @@ impl Hex {
         Self::new(-self.y, -self.z())
     }
 
-    #[deprecated = "Use Hex::cw_around"]
+    #[deprecated(since = "0.6.0", note = "Use Hex::cw_around")]
     #[inline]
     #[must_use]
     /// Rotates `self` around `center` clockwise (by 60 degrees)
@@ -849,7 +849,7 @@ impl Hex {
         self.const_sub(center).clockwise().const_add(center)
     }
 
-    #[deprecated = "Use Hex::rotate_cw"]
+    #[deprecated(since = "0.6.0", note = "Use Hex::rotate_cw")]
     #[inline]
     #[must_use]
     /// Rotates `self` around [`Hex::ZERO`] clockwise by `m` (by `60 * m` degrees)
@@ -871,7 +871,7 @@ impl Hex {
         }
     }
 
-    #[deprecated = "Use Hex::rotate_cw_around"]
+    #[deprecated(since = "0.6.0", note = "Use Hex::rotate_cw_around")]
     #[inline]
     #[must_use]
     /// Rotates `self` around `center` clockwise by `m` (by `60 * m` degrees)
@@ -1028,11 +1028,7 @@ impl Hex {
     pub const fn wraparound_mirrors(radius: u32) -> [Self; 6] {
         let radius = radius as i32;
         let mirror = Self::new(2 * radius + 1, -radius);
-        let [center, left, right] = [
-            mirror,
-            mirror.counter_clockwise(),
-            mirror.counter_clockwise(),
-        ];
+        let [center, left, right] = [mirror, mirror.counter_clockwise(), mirror.clockwise()];
         [
             left,
             center,

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -714,6 +714,7 @@ impl Hex {
         Self::DIAGONAL_COORDS.map(|n| self + n)
     }
 
+    #[deprecated = "Use Hex::counter_clockwise"]
     #[inline]
     #[must_use]
     /// Rotates `self` around [`Hex::ZERO`] counter clockwise (by -60 degrees)
@@ -727,37 +728,79 @@ impl Hex {
     /// assert_eq!(p.left(), Hex::new(3, -1));
     /// ```
     pub const fn left(self) -> Self {
+        self.counter_clockwise()
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "ccw")]
+    /// Rotates `self` around [`Hex::ZERO`] counter clockwise (by -60 degrees)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let p = Hex::new(1, 2);
+    /// assert_eq!(p.counter_clockwise(), Hex::new(3, -1));
+    /// ```
+    pub const fn counter_clockwise(self) -> Self {
         Self::new(-self.z(), -self.x)
+    }
+
+    #[deprecated = "Use Hex::ccw_around"]
+    #[inline]
+    #[must_use]
+    /// Rotates `self` around `center` counter clockwise (by -60 degrees)
+    pub const fn left_around(self, center: Self) -> Self {
+        self.ccw_around(center)
     }
 
     #[inline]
     #[must_use]
     /// Rotates `self` around `center` counter clockwise (by -60 degrees)
-    pub const fn left_around(self, center: Self) -> Self {
-        self.const_sub(center).left().const_add(center)
+    pub const fn ccw_around(self, center: Self) -> Self {
+        self.const_sub(center).counter_clockwise().const_add(center)
+    }
+
+    #[deprecated = "Use Hex::rotate_ccw"]
+    #[inline]
+    #[must_use]
+    /// Rotates `self` around [`Hex::ZERO`] counter clockwise by `m` (by `-60 * m` degrees)
+    pub const fn rotate_left(self, m: u32) -> Self {
+        self.rotate_ccw(m)
     }
 
     #[inline]
     #[must_use]
     /// Rotates `self` around [`Hex::ZERO`] counter clockwise by `m` (by `-60 * m` degrees)
-    pub const fn rotate_left(self, m: u32) -> Self {
+    pub const fn rotate_ccw(self, m: u32) -> Self {
         match m % 6 {
-            1 => self.left(),
-            2 => self.left().left(),
+            1 => self.counter_clockwise(),
+            2 => self.counter_clockwise().counter_clockwise(),
             3 => self.const_neg(),
-            4 => self.right().right(),
-            5 => self.right(),
+            4 => self.clockwise().clockwise(),
+            5 => self.clockwise(),
             _ => self,
         }
+    }
+
+    #[deprecated = "Use Hex::rotate_ccw_around"]
+    #[inline]
+    #[must_use]
+    /// Rotates `self` around `center` counter clockwise by `m` (by `-60 * m` degrees)
+    pub const fn rotate_left_around(self, center: Self, m: u32) -> Self {
+        self.rotate_ccw_around(center, m)
     }
 
     #[inline]
     #[must_use]
     /// Rotates `self` around `center` counter clockwise by `m` (by `-60 * m` degrees)
-    pub const fn rotate_left_around(self, center: Self, m: u32) -> Self {
-        self.const_sub(center).rotate_left(m).const_add(center)
+    pub const fn rotate_ccw_around(self, center: Self, m: u32) -> Self {
+        self.const_sub(center).rotate_ccw(m).const_add(center)
     }
 
+    #[deprecated = "Use Hex::clockwise"]
     #[inline]
     #[must_use]
     /// Rotates `self` around [`Hex::ZERO`] clockwise (by 60 degrees)
@@ -771,35 +814,76 @@ impl Hex {
     /// assert_eq!(p.right(), Hex::new(-2, 3));
     /// ```
     pub const fn right(self) -> Self {
+        self.clockwise()
+    }
+
+    #[inline]
+    #[must_use]
+    #[doc(alias = "cw")]
+    /// Rotates `self` around [`Hex::ZERO`] clockwise (by 60 degrees)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let p = Hex::new(1, 2);
+    /// assert_eq!(p.clockwise(), Hex::new(-2, 3));
+    /// ```
+    pub const fn clockwise(self) -> Self {
         Self::new(-self.y, -self.z())
+    }
+
+    #[deprecated = "Use Hex::cw_around"]
+    #[inline]
+    #[must_use]
+    /// Rotates `self` around `center` clockwise (by 60 degrees)
+    pub const fn right_around(self, center: Self) -> Self {
+        self.cw_around(center)
     }
 
     #[inline]
     #[must_use]
     /// Rotates `self` around `center` clockwise (by 60 degrees)
-    pub const fn right_around(self, center: Self) -> Self {
-        self.const_sub(center).right().const_add(center)
+    pub const fn cw_around(self, center: Self) -> Self {
+        self.const_sub(center).clockwise().const_add(center)
+    }
+
+    #[deprecated = "Use Hex::rotate_cw"]
+    #[inline]
+    #[must_use]
+    /// Rotates `self` around [`Hex::ZERO`] clockwise by `m` (by `60 * m` degrees)
+    pub const fn rotate_right(self, m: u32) -> Self {
+        self.rotate_cw(m)
     }
 
     #[inline]
     #[must_use]
     /// Rotates `self` around [`Hex::ZERO`] clockwise by `m` (by `60 * m` degrees)
-    pub const fn rotate_right(self, m: u32) -> Self {
+    pub const fn rotate_cw(self, m: u32) -> Self {
         match m % 6 {
-            1 => self.right(),
-            2 => self.right().right(),
+            1 => self.clockwise(),
+            2 => self.clockwise().clockwise(),
             3 => self.const_neg(),
-            4 => self.left().left(),
-            5 => self.left(),
+            4 => self.counter_clockwise().counter_clockwise(),
+            5 => self.counter_clockwise(),
             _ => self,
         }
+    }
+
+    #[deprecated = "Use Hex::rotate_cw_around"]
+    #[inline]
+    #[must_use]
+    /// Rotates `self` around `center` clockwise by `m` (by `60 * m` degrees)
+    pub const fn rotate_right_around(self, center: Self, m: u32) -> Self {
+        self.rotate_cw_around(center, m)
     }
 
     #[inline]
     #[must_use]
     /// Rotates `self` around `center` clockwise by `m` (by `60 * m` degrees)
-    pub const fn rotate_right_around(self, center: Self, m: u32) -> Self {
-        self.const_sub(center).rotate_right(m).const_add(center)
+    pub const fn rotate_cw_around(self, center: Self, m: u32) -> Self {
+        self.const_sub(center).rotate_cw(m).const_add(center)
     }
 
     #[inline]
@@ -944,7 +1028,11 @@ impl Hex {
     pub const fn wraparound_mirrors(radius: u32) -> [Self; 6] {
         let radius = radius as i32;
         let mirror = Self::new(2 * radius + 1, -radius);
-        let [center, left, right] = [mirror, mirror.left(), mirror.right()];
+        let [center, left, right] = [
+            mirror,
+            mirror.counter_clockwise(),
+            mirror.counter_clockwise(),
+        ];
         [
             left,
             center,

--- a/src/hex/rings.rs
+++ b/src/hex/rings.rs
@@ -113,10 +113,10 @@ impl Hex {
         clockwise: bool,
     ) -> impl ExactSizeIterator<Item = Self> {
         let [start_dir, end_dir] = if clockwise {
-            let dir = direction.direction_left();
+            let dir = direction.direction_ccw();
             [dir, dir >> 2]
         } else {
-            let dir = direction.direction_right();
+            let dir = direction.direction_cw();
             [dir, dir << 2]
         };
         let p = self + start_dir * radius as i32;
@@ -300,8 +300,8 @@ impl Hex {
         range: impl Iterator<Item = u32> + Clone,
         direction: Direction,
     ) -> impl Iterator<Item = Self> {
-        let left = self.wedge(range.clone(), direction.diagonal_left());
-        let right = self.wedge(range, direction.diagonal_right());
+        let left = self.wedge(range.clone(), direction.diagonal_ccw());
+        let right = self.wedge(range, direction.diagonal_cw());
         left.chain(right)
             .filter(move |h| self.way_to(*h) == direction)
     }

--- a/src/hex/tests.rs
+++ b/src/hex/tests.rs
@@ -228,61 +228,61 @@ fn rotation() {
         let [next, prev] = [elems[0], elems[1]];
         let prev_dir = Hex::ZERO.way_to(prev).unwrap();
         let next_dir = Hex::ZERO.way_to(next).unwrap();
-        assert_eq!(prev.right(), next);
-        assert_eq!(next.left(), prev);
-        assert_eq!(prev_dir.right(), next_dir);
-        assert_eq!(next_dir.left(), prev_dir);
+        assert_eq!(prev.clockwise(), next);
+        assert_eq!(next.counter_clockwise(), prev);
+        assert_eq!(prev_dir.clockwise(), next_dir);
+        assert_eq!(next_dir.counter_clockwise(), prev_dir);
     }
 }
 
 #[test]
-fn rotate_right() {
+fn rotate_cw() {
     let point = Hex::new(5, 0);
-    let new = point.right();
+    let new = point.clockwise();
     assert_eq!(new, Hex::new(0, 5));
-    assert_eq!(point.rotate_right(1), new);
-    let new = new.right();
+    assert_eq!(point.rotate_cw(1), new);
+    let new = new.clockwise();
     assert_eq!(new, Hex::new(-5, 5));
-    assert_eq!(point.rotate_right(2), new);
-    let new = new.right();
+    assert_eq!(point.rotate_cw(2), new);
+    let new = new.clockwise();
     assert_eq!(new, Hex::new(-5, 0));
-    assert_eq!(point.rotate_right(3), new);
-    let new = new.right();
+    assert_eq!(point.rotate_cw(3), new);
+    let new = new.clockwise();
     assert_eq!(new, Hex::new(0, -5));
-    assert_eq!(point.rotate_right(4), new);
-    let new = new.right();
+    assert_eq!(point.rotate_cw(4), new);
+    let new = new.clockwise();
     assert_eq!(new, Hex::new(5, -5));
-    assert_eq!(point.rotate_right(5), new);
-    let new = new.right();
+    assert_eq!(point.rotate_cw(5), new);
+    let new = new.clockwise();
     assert_eq!(new, point);
-    assert_eq!(point.rotate_right(6), new);
-    assert_eq!(point.rotate_right(7), point.rotate_right(1));
-    assert_eq!(point.rotate_right(10), point.rotate_right(4));
+    assert_eq!(point.rotate_cw(6), new);
+    assert_eq!(point.rotate_cw(7), point.rotate_cw(1));
+    assert_eq!(point.rotate_cw(10), point.rotate_cw(4));
 }
 
 #[test]
-fn rotate_left() {
+fn rotate_ccw() {
     let point = Hex::new(5, 0);
-    let new = point.left();
+    let new = point.counter_clockwise();
     assert_eq!(new, Hex::new(5, -5));
-    assert_eq!(point.rotate_left(1), new);
-    let new = new.left();
+    assert_eq!(point.rotate_ccw(1), new);
+    let new = new.counter_clockwise();
     assert_eq!(new, Hex::new(0, -5));
-    assert_eq!(point.rotate_left(2), new);
-    let new = new.left();
+    assert_eq!(point.rotate_ccw(2), new);
+    let new = new.counter_clockwise();
     assert_eq!(new, Hex::new(-5, 0));
-    assert_eq!(point.rotate_left(3), new);
-    let new = new.left();
+    assert_eq!(point.rotate_ccw(3), new);
+    let new = new.counter_clockwise();
     assert_eq!(new, Hex::new(-5, 5));
-    assert_eq!(point.rotate_left(4), new);
-    let new = new.left();
+    assert_eq!(point.rotate_ccw(4), new);
+    let new = new.counter_clockwise();
     assert_eq!(new, Hex::new(0, 5));
-    assert_eq!(point.rotate_left(5), new);
-    let new = new.left();
+    assert_eq!(point.rotate_ccw(5), new);
+    let new = new.counter_clockwise();
     assert_eq!(new, point);
-    assert_eq!(point.rotate_left(6), new);
-    assert_eq!(point.rotate_left(7), point.rotate_left(1));
-    assert_eq!(point.rotate_left(10), point.rotate_left(4));
+    assert_eq!(point.rotate_ccw(6), new);
+    assert_eq!(point.rotate_ccw(7), point.rotate_ccw(1));
+    assert_eq!(point.rotate_ccw(10), point.rotate_ccw(4));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #76 

Open question: Should the functions be
- spelled out: `clockwise`/`counter_clockwise`
- abbreviated: `cw`/`ccw`
- abbreviated only in compounds: e.g. `clockwise()` and `rotate_ccw_around()`