### PR TITLE
Hex::xrange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* Added `Hex::xrange` for excluding range coordinates (#88)
+* Implemented  `PartialEq` For `HexOrientation` (#87)
+
 ## 0.6.0
 
 * Changed logo (#63)
@@ -20,7 +23,6 @@
 * Added field of movement algorithm in `algorithms`:
   - `field_of_movement` provides the available range of field of movement given a `budget` of movement and a movement `cost`
 * Renamed rotation functions to follow `cw`/`ccw` terminology (old versions deprecated) (#78)
-* Implemented  `PartialEq` For `HexOrientation` (#83)
 
 ### Directions to
 

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -258,7 +258,7 @@ impl Direction {
         }
     }
 
-    #[deprecated(since = "0.6.0", note = "Use Direction::ccw")]
+    #[deprecated(since = "0.6.0", note = "Use Direction::counter_clockwise")]
     #[inline]
     #[must_use]
     /// Returns the next direction in counter clockwise order

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -967,8 +967,9 @@ impl Hex {
         let radius = range as i32;
         ExactSizeHexIterator {
             iter: (-radius..=radius).flat_map(move |x| {
-                (max(-radius, -x - radius)..=min(radius, radius - x))
-                    .map(move |y| self.const_add(Self::new(x, y)))
+                let y_min = max(-radius, -x - radius);
+                let y_max = min(radius, radius - x);
+                (y_min..=y_max).map(move |y| self.const_add(Self::new(x, y)))
             }),
             count: Self::range_count(range),
         }
@@ -994,7 +995,9 @@ impl Hex {
         let radius = range as i32;
         ExactSizeHexIterator {
             iter: (-radius..=radius).flat_map(move |x| {
-                (max(-radius, -x - radius)..=min(radius, radius - x))
+                let y_min = max(-radius, -x - radius);
+                let y_max = min(radius, radius - x);
+                (y_min..=y_max)
                     .map(move |y| self.const_add(Self::new(x, y)))
                     .filter(move |h| *h != self)
             }),

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -952,6 +952,17 @@ impl Hex {
     #[must_use]
     /// Retrieves all [`Hex`] around `self` in a given `range`.
     /// The number of returned coordinates is equal to `Hex::range_count(range)`
+    ///
+    /// > See also [`Hex::xrange`] to retrieve all coordinates excluding `self`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let coord = hex(12, 34);
+    /// assert_eq!(coord.range(0).len(), 1);
+    /// assert_eq!(coord.range(1).len(), 7);
+    /// ```
     pub fn range(self, range: u32) -> impl ExactSizeIterator<Item = Self> {
         let radius = range as i32;
         ExactSizeHexIterator {
@@ -960,6 +971,34 @@ impl Hex {
                     .map(move |y| self.const_add(Self::new(x, y)))
             }),
             count: Self::range_count(range),
+        }
+    }
+
+    #[allow(clippy::cast_possible_wrap)]
+    #[doc(alias = "excluding_range")]
+    #[must_use]
+    /// Retrieves all [`Hex`] around `self` in a given `range` except `self`.
+    /// The number of returned coordinates is equal to `Hex::range_count(range) - 1`
+    ///
+    /// > See also [`Hex::range`] to retrieve all coordinates including `self`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let coord = hex(12, 34);
+    /// assert_eq!(coord.xrange(0).len(), 0);
+    /// assert_eq!(coord.xrange(1).len(), 6);
+    /// ```
+    pub fn xrange(self, range: u32) -> impl ExactSizeIterator<Item = Self> {
+        let radius = range as i32;
+        ExactSizeHexIterator {
+            iter: (-radius..=radius).flat_map(move |x| {
+                (max(-radius, -x - radius)..=min(radius, radius - x))
+                    .map(move |y| self.const_add(Self::new(x, y)))
+                    .filter(move |h| *h != self)
+            }),
+            count: Self::range_count(range).saturating_sub(1),
         }
     }
 
@@ -972,6 +1011,7 @@ impl Hex {
     /// ```rust
     /// # use hexx::*;
     /// assert_eq!(Hex::range_count(15), 721);
+    /// assert_eq!(Hex::range_count(0), 1);
     /// ```
     pub const fn range_count(range: u32) -> usize {
         (3 * range * (range + 1) + 1) as usize


### PR DESCRIPTION
Added `Hex::xrange`, an equivalent of `Hex::range` without the center coordinate