### PR TITLE
HexOrientaion is now an enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Added `Hex::xrange` for excluding range coordinates (#88)
 * Implemented  `PartialEq` For `HexOrientation` (#87)
+* `HexOrientation` is now a two variant enum instead of a struct:
+  * The inner data (matrices and rotation) are now retrievable through either:
+    * `orientation_data()` method
+    * `Deref` implementation
 
 ## 0.6.0
 
@@ -12,17 +16,19 @@
 * (**BREAKING**) Removed deprecated `Hex::directions_to` method (#58)
 * Added `MeshInfo::facing` utils method to rotate hex meshes (#65)
 * Added `hex` utils function to create an `Hex`, making it less boilerplate (#66):
-  - Before: `Hex::new()`
-  - Now: `hex()`
+  * Before: `Hex::new()`
+  * Now: `hex()`
 * `Hex` won't derive `Debug` or `Hash` on spirv archs (#66)
 * Added `packed` feature to make `Hex` `repr(C)` (#67)
 * Added an `algorithms` module with a `a_star` implementation (#69)
 * Added field of view algorithms in `algorithms`:
-  - `range_fov` omni-directional field of view
-  - `directional_fov` directional 120 degrees field of view (`Direction`)
+  * `range_fov` omni-directional field of view
+  * `directional_fov` directional 120 degrees field of view (`Direction`)
 * Added field of movement algorithm in `algorithms`:
-  - `field_of_movement` provides the available range of field of movement given a `budget` of movement and a movement `cost`
-* Renamed rotation functions to follow `cw`/`ccw` terminology (old versions deprecated) (#78)
+  * `field_of_movement` provides the available range of field of movement given
+  a `budget` of movement and a movement `cost`
+* Renamed rotation functions to follow `cw`/`ccw` terminology
+(old versions deprecated) (#78)
 
 ### Directions to
 
@@ -59,12 +65,12 @@ But now with accurate results !
 * Deprecated `MeshInfo::hexagonal_column` and `MeshInfo::partial_hexagonal_column`
 * (**BREAKING**) `MeshInfo` fields use `glam` types instead of arrays of float
 * Added `ColumnMeshBuilder` to create hex column meshes. This allows more customization options than the previous way:
-  - Rotation
-  - Offset
-  - Sides subdivisions
+  * Rotation
+  * Offset
+  * Sides subdivisions
 * Added `PlaneMeshBuilder` to create hex plane meshes. This allows more customization options than the previous way:
-  - Rotation
-  - Offset
+  * Rotation
+  * Offset
 * (**BREAKING**) Removed `MeshInfo::facing` method.
 * Added `MeshInfo::rotated` method
 * Added `MeshInfo::with_offset` method
@@ -252,11 +258,11 @@ But now with accurate results !
 ### Direction
 
 * Added angle methods to `Direction`:
-  - `angle_flat` for radian angle in flat orientation
-  - `angle_flat_degrees` for degrees angle in flat orientation
-  - `angle_pointy` for radian angle in pointy orientation
-  - `angle_pointy_degrees` for degrees angle in pointy orientation
-  - `angle` for radian angle in a given orientation
+  * `angle_flat` for radian angle in flat orientation
+  * `angle_flat_degrees` for degrees angle in flat orientation
+  * `angle_pointy` for radian angle in pointy orientation
+  * `angle_pointy_degrees` for degrees angle in pointy orientation
+  * `angle` for radian angle in a given orientation
 * (**BREAKING**) rotated order of `Direction` enum and `Hex::ALL_NEIGHBORS` by 1 to the left, `TopRight` is now the first as `BottomRight` is now last
 * Added `left` and `right` methods to `Direction` to get the next direction clockwise and counter clockwise
 * Added `rotate_left` and `rotate_right` methods to `Direction` to rotate the direction clockwise and counter clockwise by a custom amount

--- a/benches/rings.rs
+++ b/benches/rings.rs
@@ -6,6 +6,12 @@ pub fn rings_benchmark(c: &mut Criterion) {
     group.significance_level(0.1).sample_size(100);
     let dist: u32 = 1000;
 
+    group.bench_with_input(BenchmarkId::new("Range", dist), &dist, |b, dist| {
+        b.iter(|| Hex::range(black_box(Hex::ZERO), *dist).collect::<Vec<_>>())
+    });
+    group.bench_with_input(BenchmarkId::new("XRange", dist), &dist, |b, dist| {
+        b.iter(|| Hex::xrange(black_box(Hex::ZERO), *dist).collect::<Vec<_>>())
+    });
     group.bench_with_input(BenchmarkId::new("Ring", dist), &dist, |b, dist| {
         b.iter(|| Hex::ring(black_box(Hex::ZERO), *dist).collect::<Vec<_>>())
     });
@@ -14,9 +20,6 @@ pub fn rings_benchmark(c: &mut Criterion) {
     });
     group.bench_with_input(BenchmarkId::new("Spiral Rings", dist), &dist, |b, dist| {
         b.iter(|| Hex::spiral_range(black_box(Hex::ZERO), 0..=*dist).collect::<Vec<_>>())
-    });
-    group.bench_with_input(BenchmarkId::new("Range", dist), &dist, |b, dist| {
-        b.iter(|| Hex::range(black_box(Hex::ZERO), *dist).collect::<Vec<_>>())
     });
     group.finish();
 }

--- a/src/direction/tests.rs
+++ b/src/direction/tests.rs
@@ -75,7 +75,7 @@ mod hex_directions {
             (Bottom, 3.0 * PI / 2.0),
             (BottomRight, 11.0 * PI / 6.0),
         ];
-        let orientation = HexOrientation::flat();
+        let orientation = HexOrientation::Flat;
         for (dir, angle) in expected {
             assert!(dir.angle_flat() - angle <= EPSILON);
             assert!(dir.angle(&orientation) - angle <= EPSILON);
@@ -107,7 +107,7 @@ mod hex_directions {
             (Bottom, 4.0 * PI / 3.0),
             (BottomRight, 5.0 * PI / 3.0),
         ];
-        let orientation = HexOrientation::pointy();
+        let orientation = HexOrientation::Pointy;
         for (dir, angle) in expected {
             assert!(dir.angle_pointy() - angle <= EPSILON);
             assert!(dir.angle(&orientation) - angle <= EPSILON);

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -11,7 +11,7 @@ use glam::Vec2;
 ///
 /// let layout = HexLayout {
 ///     // We want flat topped hexagons
-///     orientation: HexOrientation::flat(),
+///     orientation: HexOrientation::Flat,
 ///     // We define the world space origin equivalent of `Hex::ZERO` in hex space
 ///     origin: Vec2::new(1.0, 2.0),
 ///     // We define the world space size of the hexagons
@@ -88,7 +88,7 @@ mod tests {
     fn flat_corners() {
         let point = Hex::new(0, 0);
         let layout = HexLayout {
-            orientation: HexOrientation::flat(),
+            orientation: HexOrientation::Flat,
             origin: Vec2::ZERO,
             hex_size: Vec2::new(10., 10.),
         };
@@ -110,7 +110,7 @@ mod tests {
     fn pointy_corners() {
         let point = Hex::new(0, 0);
         let layout = HexLayout {
-            orientation: HexOrientation::pointy(),
+            orientation: HexOrientation::Pointy,
             origin: Vec2::ZERO,
             hex_size: Vec2::new(10., 10.),
         };

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -1,17 +1,19 @@
+use std::ops::Deref;
+
 use crate::direction::angles::DIRECTION_ANGLE_OFFSET;
 use crate::Direction;
 
 const SQRT_3: f32 = 1.732_050_8;
 
 // TODO: make const
-static POINTY_ORIENTATION: HexOrientation = HexOrientation {
+static POINTY_ORIENTATION: HexOrientationData = HexOrientationData {
     forward_matrix: [SQRT_3, SQRT_3 / 2.0, 0.0, 3.0 / 2.0],
     inverse_matrix: [SQRT_3 / 3.0, -1.0 / 3.0, 0.0, 2.0 / 3.0],
     angle_offset: DIRECTION_ANGLE_OFFSET, // 30 degrees
 };
 
 // TODO: make const
-static FLAT_ORIENTATION: HexOrientation = HexOrientation {
+static FLAT_ORIENTATION: HexOrientationData = HexOrientationData {
     forward_matrix: [3.0 / 2.0, 0.0, SQRT_3 / 2.0, SQRT_3],
     inverse_matrix: [2.0 / 3.0, 0.0, -1.0 / 3.0, SQRT_3 / 3.0],
     angle_offset: 0.0, // 0 degrees
@@ -26,9 +28,9 @@ static FLAT_ORIENTATION: HexOrientation = HexOrientation {
 /// let flat = HexOrientation::flat();
 /// let pointy = HexOrientation::pointy();
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
-pub struct HexOrientation {
+pub struct HexOrientationData {
     /// Matrix used to compute hexagonal coordinates to world/pixel coordinates
     pub(crate) forward_matrix: [f32; 4],
     /// Matrix used to compute world/pixel coordinates to hexagonal coordinates
@@ -37,19 +39,32 @@ pub struct HexOrientation {
     pub(crate) angle_offset: f32,
 }
 
+/// Hexagonal orientation, either [`Pointy`] or [`Flat`]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+pub enum HexOrientation {
+    /// *Pointy* orientation, means that the hexagons are *pointy-topped*
+    Pointy,
+    /// *Flat* orientation, means that the hexagons are *flat-topped*
+    #[default]
+    Flat,
+}
+
 impl HexOrientation {
     #[inline]
     #[must_use]
+    #[deprecated(since = "0.7.0", note = "Use HexOrientation::Pointy instead")]
     /// "Pointy top" hexagonal orientation⬢
-    pub fn pointy() -> Self {
-        POINTY_ORIENTATION
+    pub const fn pointy() -> Self {
+        Self::Pointy
     }
 
     #[inline]
     #[must_use]
+    #[deprecated(since = "0.7.0", note = "Use HexOrientation::Flat instead")]
     /// "Flat top" hexagonal orientation
-    pub fn flat() -> Self {
-        FLAT_ORIENTATION
+    pub const fn flat() -> Self {
+        Self::Flat
     }
 
     #[must_use]
@@ -58,10 +73,22 @@ impl HexOrientation {
     pub fn direction_angle(&self, direction: Direction) -> f32 {
         direction.angle(self)
     }
+
+    #[must_use]
+    #[inline]
+    /// Returns the orientation inner data, rotation angle and matrices
+    pub fn orientation_data(&self) -> &'static HexOrientationData {
+        match self {
+            Self::Pointy => &POINTY_ORIENTATION,
+            Self::Flat => &FLAT_ORIENTATION,
+        }
+    }
 }
 
-impl Default for HexOrientation {
-    fn default() -> Self {
-        Self::flat()
+impl Deref for HexOrientation {
+    type Target = HexOrientationData;
+
+    fn deref(&self) -> &Self::Target {
+        self.orientation_data()
     }
 }


### PR DESCRIPTION
> Closes #86 
> Addresses #85 

# Work done

`HexOrientation` is now a two variant enum instead of a struct. The inner data (matrices and rotation) was renamed `HexOrientationData` and is now retrievable through either:
    * `HexOrientation::orientation_data()` method
    * `Deref` implementation
