### PR TITLE
Directions from angle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@
   * The inner data (matrices and rotation) are now retrievable through either:
     * `orientation_data()` method
     * `Deref` implementation
+* Added conversion from angles for both `Direction` and `DiagonalDirection` (#92):
+  * `Direction::from_angle`
+  * `Direction::from_pointy_angle`
+  * `Direction::from_flat_angle`
+  * `Direction::from_angle_degrees`
+  * `Direction::from_pointy_angle_degrees`
+  * `Direction::from_flat_angle_degrees`
+  * `DiagonalDirection::from_angle`
+  * `DiagonalDirection::from_pointy_angle`
+  * `DiagonalDirection::from_flat_angle`
+  * `DiagonalDirection::from_angle_degrees`
+  * `DiagonalDirection::from_pointy_angle_degrees`
+  * `DiagonalDirection::from_flat_angle_degrees`
+* Added missing `Direction::angle_degrees` method (#92)
+* Added missing `DiagonalDirection::angle_degrees` method (#92)
 
 ## 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@
  // Define your layout
  let layout = HexLayout {
     hex_size: Vec2::new(1.0, 1.0),
-    orientation: HexOrientation::flat(),
+    orientation: HexOrientation::Flat,
     ..Default::default()
  };
  // Get the hex coordinate at the world position `world_pos`.

--- a/src/direction/diagonal_direction.rs
+++ b/src/direction/diagonal_direction.rs
@@ -431,7 +431,7 @@ impl DiagonalDirection {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let direction = DiagonalDirection::from_pointy_angle_degrees(35.0);
+    /// let direction = DiagonalDirection::from_flat_angle_degrees(15.0);
     /// assert_eq!(direction, DiagonalDirection::Right);
     /// ```
     pub fn from_flat_angle_degrees(angle: f32) -> Self {
@@ -447,8 +447,8 @@ impl DiagonalDirection {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let direction = DiagonalDirection::from_flat_angle_degrees(35.0);
-    /// assert_eq!(direction, Direction::TopRight);
+    /// let direction = DiagonalDirection::from_pointy_angle_degrees(15.0);
+    /// assert_eq!(direction, DiagonalDirection::TopRight);
     /// ```
     pub fn from_pointy_angle_degrees(angle: f32) -> Self {
         let angle = angle % 360.0;
@@ -473,8 +473,8 @@ impl DiagonalDirection {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let direction = DiagonalDirection::from_pointy_angle_degrees(0.6);
-    /// assert_eq!(direction, Direction::TopRight);
+    /// let direction = DiagonalDirection::from_flat_angle(0.26);
+    /// assert_eq!(direction, DiagonalDirection::Right);
     /// ```
     pub fn from_flat_angle(angle: f32) -> Self {
         Self::from_pointy_angle(angle - DIRECTION_ANGLE_OFFSET_RAD)
@@ -489,8 +489,8 @@ impl DiagonalDirection {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let direction = DiagonalDirection::from_flat_angle(0.6);
-    /// assert_eq!(direction, Direction::Top);
+    /// let direction = DiagonalDirection::from_pointy_angle(0.26);
+    /// assert_eq!(direction, DiagonalDirection::TopRight);
     /// ```
     pub fn from_pointy_angle(angle: f32) -> Self {
         let angle = angle % PI_2;
@@ -515,7 +515,7 @@ impl DiagonalDirection {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let angle = 35.0;
+    /// let angle = 15.0;
     /// assert_eq!(DiagonalDirection::from_angle_degrees(angle, &HexOrientation::Flat), DiagonalDirection::Right);
     /// assert_eq!(DiagonalDirection::from_angle_degrees(angle, &HexOrientation::Pointy), DiagonalDirection::TopRight);
     /// ```
@@ -534,7 +534,7 @@ impl DiagonalDirection {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let angle = 0.6;
+    /// let angle = 0.26;
     /// assert_eq!(DiagonalDirection::from_angle(angle, &HexOrientation::Flat), DiagonalDirection::Right);
     /// assert_eq!(DiagonalDirection::from_angle(angle, &HexOrientation::Pointy), DiagonalDirection::TopRight);
     /// ```

--- a/src/direction/diagonal_direction.rs
+++ b/src/direction/diagonal_direction.rs
@@ -74,7 +74,7 @@ pub enum DiagonalDirection {
     /// |orientation |radians|degrees|
     /// |------------|-------|-------|
     /// | Flat Top   |  π/3  |  60   |   
-    /// | Flat Top   |  π/6  |  30   |   
+    /// | Pointy Top |  π/6  |  30   |
     ///
     /// ```txt
     ///            x Axis

--- a/src/direction/diagonal_direction.rs
+++ b/src/direction/diagonal_direction.rs
@@ -383,7 +383,7 @@ impl DiagonalDirection {
     ///
     /// See [`Self::angle_flat`] for *flat* hexagons
     pub fn angle_pointy(self) -> f32 {
-        self.angle_flat() - DIRECTION_ANGLE_OFFSET
+        self.angle_flat() - DIRECTION_ANGLE_OFFSET_RAD
     }
 
     #[inline]
@@ -409,6 +409,140 @@ impl DiagonalDirection {
     /// Returns the angle in radians of the given direction in the given `orientation`
     pub fn angle(self, orientation: &HexOrientation) -> f32 {
         self.angle_pointy() - orientation.angle_offset
+    }
+
+    #[inline]
+    #[must_use]
+    /// Returns the angle in degrees of the given direction according to its `orientation`
+    ///
+    /// See [`Self::angle`] for radians angles
+    pub fn angle_degrees(self, orientation: &HexOrientation) -> f32 {
+        match orientation {
+            HexOrientation::Pointy => self.angle_pointy_degrees(),
+            HexOrientation::Flat => self.angle_flat_degrees(),
+        }
+    }
+
+    #[must_use]
+    /// Returns the direction from the given `angle` in degrees
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let direction = DiagonalDirection::from_pointy_angle_degrees(35.0);
+    /// assert_eq!(direction, DiagonalDirection::Right);
+    /// ```
+    pub fn from_flat_angle_degrees(angle: f32) -> Self {
+        Self::from_pointy_angle_degrees(angle - DIRECTION_ANGLE_OFFSET_DEGREES)
+    }
+
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    /// Returns the direction from the given `angle` in degrees
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let direction = DiagonalDirection::from_flat_angle_degrees(35.0);
+    /// assert_eq!(direction, Direction::TopRight);
+    /// ```
+    pub fn from_pointy_angle_degrees(angle: f32) -> Self {
+        let angle = angle % 360.0;
+        let angle = if angle < 0.0 { angle + 360.0 } else { angle };
+        let sector = (angle / DIRECTION_ANGLE_DEGREES).trunc() as i32;
+        println!("{angle} - {sector}");
+        match sector {
+            0 => Self::TopRight,
+            1 => Self::TopLeft,
+            2 => Self::Left,
+            3 => Self::BottomLeft,
+            4 => Self::BottomRight,
+            _ => Self::Right,
+        }
+    }
+
+    #[must_use]
+    /// Returns the direction from the given `angle` in radians
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let direction = DiagonalDirection::from_pointy_angle_degrees(0.6);
+    /// assert_eq!(direction, Direction::TopRight);
+    /// ```
+    pub fn from_flat_angle(angle: f32) -> Self {
+        Self::from_pointy_angle(angle - DIRECTION_ANGLE_OFFSET_RAD)
+    }
+
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    /// Returns the direction from the given `angle` in radians
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let direction = DiagonalDirection::from_flat_angle(0.6);
+    /// assert_eq!(direction, Direction::Top);
+    /// ```
+    pub fn from_pointy_angle(angle: f32) -> Self {
+        let angle = angle % PI_2;
+        let angle = if angle < 0.0 { angle + PI_2 } else { angle };
+        let sector = (angle / DIRECTION_ANGLE_RAD) as i32;
+        println!("{angle} - {sector}");
+        match sector {
+            0 => Self::TopRight,
+            1 => Self::TopLeft,
+            2 => Self::Left,
+            3 => Self::BottomLeft,
+            4 => Self::BottomRight,
+            _ => Self::Right,
+        }
+    }
+
+    #[must_use]
+    /// Returns the direction from the given `angle` in degrees according the `orientation`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let angle = 35.0;
+    /// assert_eq!(DiagonalDirection::from_angle_degrees(angle, &HexOrientation::Flat), DiagonalDirection::Right);
+    /// assert_eq!(DiagonalDirection::from_angle_degrees(angle, &HexOrientation::Pointy), DiagonalDirection::TopRight);
+    /// ```
+    pub fn from_angle_degrees(angle: f32, orientation: &HexOrientation) -> Self {
+        match orientation {
+            HexOrientation::Pointy => Self::from_pointy_angle_degrees(angle),
+            HexOrientation::Flat => Self::from_flat_angle_degrees(angle),
+        }
+    }
+
+    #[must_use]
+    /// Returns the direction from the given `angle` in radians according the `orientation`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let angle = 0.6;
+    /// assert_eq!(DiagonalDirection::from_angle(angle, &HexOrientation::Flat), DiagonalDirection::Right);
+    /// assert_eq!(DiagonalDirection::from_angle(angle, &HexOrientation::Pointy), DiagonalDirection::TopRight);
+    /// ```
+    pub fn from_angle(angle: f32, orientation: &HexOrientation) -> Self {
+        match orientation {
+            HexOrientation::Pointy => Self::from_pointy_angle(angle),
+            HexOrientation::Flat => Self::from_flat_angle(angle),
+        }
     }
 
     #[deprecated(since = "0.6.0", note = "Use DiagonalDirection::direction_ccw")]

--- a/src/direction/diagonal_direction.rs
+++ b/src/direction/diagonal_direction.rs
@@ -451,8 +451,7 @@ impl DiagonalDirection {
     /// assert_eq!(direction, DiagonalDirection::TopRight);
     /// ```
     pub fn from_pointy_angle_degrees(angle: f32) -> Self {
-        let angle = angle % 360.0;
-        let angle = if angle < 0.0 { angle + 360.0 } else { angle };
+        let angle = angle.rem_euclid(360.0);
         let sector = (angle / DIRECTION_ANGLE_DEGREES).trunc() as i32;
         println!("{angle} - {sector}");
         match sector {
@@ -493,8 +492,7 @@ impl DiagonalDirection {
     /// assert_eq!(direction, DiagonalDirection::TopRight);
     /// ```
     pub fn from_pointy_angle(angle: f32) -> Self {
-        let angle = angle % PI_2;
-        let angle = if angle < 0.0 { angle + PI_2 } else { angle };
+        let angle = angle.rem_euclid(PI_2);
         let sector = (angle / DIRECTION_ANGLE_RAD) as i32;
         println!("{angle} - {sector}");
         match sector {

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -407,6 +407,48 @@ impl Direction {
         Self::POINTY_ANGLES_DEGREES[self as usize]
     }
 
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    /// Returns the direction from the given `angle` in degrees
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let direction = Direction::from_flat_angle_degrees(35.0);
+    /// assert_eq!(direction, Direction::TopRight);
+    /// ```
+    pub fn from_flat_angle_degrees(angle: f32) -> Self {
+        Self::from_pointy_angle_degrees(angle - DIRECTION_ANGLE_OFFSET_DEGREES)
+    }
+
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    /// Returns the direction from the given `angle` in degrees
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let direction = Direction::from_pointy_angle_degrees(35.0);
+    /// assert_eq!(direction, Direction::Top);
+    /// ```
+    pub fn from_pointy_angle_degrees(angle: f32) -> Self {
+        let angle = angle % 360.0;
+        let angle = if angle < 0.0 { angle + 360.0 } else { angle };
+        let half_sector = angle as i32 / 30;
+        match half_sector {
+            11 | 0 => Self::TopRight,
+            1 | 2 => Self::Top,
+            3 | 4 => Self::TopLeft,
+            5 | 6 => Self::BottomLeft,
+            7 | 8 => Self::Bottom,
+            _ => Self::BottomRight,
+        }
+    }
+
     #[inline]
     #[must_use]
     /// Returns the angle in radians of the given direction in the given `orientation`

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -454,8 +454,7 @@ impl Direction {
     /// assert_eq!(direction, Direction::TopRight);
     /// ```
     pub fn from_flat_angle_degrees(angle: f32) -> Self {
-        let angle = angle % 360.0;
-        let angle = if angle < 0.0 { angle + 360.0 } else { angle };
+        let angle = angle.rem_euclid(360.0);
         let sector = (angle / DIRECTION_ANGLE_DEGREES).trunc() as i32;
         match sector {
             0 => Self::TopRight,
@@ -495,8 +494,7 @@ impl Direction {
     /// assert_eq!(direction, Direction::TopRight);
     /// ```
     pub fn from_flat_angle(angle: f32) -> Self {
-        let angle = angle % PI_2;
-        let angle = if angle < 0.0 { angle + PI_2 } else { angle };
+        let angle = angle.rem_euclid(PI_2);
         let sector = (angle / DIRECTION_ANGLE_RAD) as i32;
         match sector {
             0 => Self::TopRight,

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -377,7 +377,7 @@ impl Direction {
     ///
     /// See [`Self::angle_pointy`] for *pointy* hexagons
     pub fn angle_flat(self) -> f32 {
-        self.angle_pointy() + DIRECTION_ANGLE_OFFSET
+        self.angle_pointy() + DIRECTION_ANGLE_OFFSET_RAD
     }
 
     #[inline]
@@ -437,8 +437,8 @@ impl Direction {
     /// let direction = Direction::from_flat_angle_degrees(35.0);
     /// assert_eq!(direction, Direction::TopRight);
     /// ```
-    pub fn from_flat_angle_degrees(angle: f32) -> Self {
-        Self::from_pointy_angle_degrees(angle - DIRECTION_ANGLE_OFFSET_DEGREES)
+    pub fn from_pointy_angle_degrees(angle: f32) -> Self {
+        Self::from_flat_angle_degrees(angle + DIRECTION_ANGLE_OFFSET_DEGREES)
     }
 
     #[must_use]
@@ -450,19 +450,19 @@ impl Direction {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let direction = Direction::from_pointy_angle_degrees(35.0);
+    /// let direction = Direction::from_flat_angle_degrees(35.0);
     /// assert_eq!(direction, Direction::Top);
     /// ```
-    pub fn from_pointy_angle_degrees(angle: f32) -> Self {
+    pub fn from_flat_angle_degrees(angle: f32) -> Self {
         let angle = angle % 360.0;
         let angle = if angle < 0.0 { angle + 360.0 } else { angle };
-        let half_sector = (angle / DIRECTION_ANGLE_OFFSET_DEGREES).trunc() as i32;
-        match half_sector {
-            11 | 0 => Self::TopRight,
-            1 | 2 => Self::Top,
-            3 | 4 => Self::TopLeft,
-            5 | 6 => Self::BottomLeft,
-            7 | 8 => Self::Bottom,
+        let sector = (angle / DIRECTION_ANGLE_DEGREES).trunc() as i32;
+        match sector {
+            0 => Self::TopRight,
+            1 => Self::Top,
+            2 => Self::TopLeft,
+            3 => Self::BottomLeft,
+            4 => Self::Bottom,
             _ => Self::BottomRight,
         }
     }
@@ -478,8 +478,8 @@ impl Direction {
     /// let direction = Direction::from_flat_angle_degrees(0.6);
     /// assert_eq!(direction, Direction::TopRight);
     /// ```
-    pub fn from_flat_angle(angle: f32) -> Self {
-        Self::from_pointy_angle(angle - DIRECTION_ANGLE_OFFSET)
+    pub fn from_pointy_angle(angle: f32) -> Self {
+        Self::from_flat_angle(angle + DIRECTION_ANGLE_OFFSET_RAD)
     }
 
     #[must_use]
@@ -491,19 +491,19 @@ impl Direction {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let direction = Direction::from_pointy_angle(0.6);
-    /// assert_eq!(direction, Direction::Top);
+    /// let direction = Direction::from_flat_angle(0.6);
+    /// assert_eq!(direction, Direction::TopRight);
     /// ```
-    pub fn from_pointy_angle(angle: f32) -> Self {
+    pub fn from_flat_angle(angle: f32) -> Self {
         let angle = angle % PI_2;
         let angle = if angle < 0.0 { angle + PI_2 } else { angle };
-        let half_sector = (angle / DIRECTION_ANGLE_OFFSET) as i32;
-        match half_sector {
-            11 | 0 => Self::TopRight,
-            1 | 2 => Self::Top,
-            3 | 4 => Self::TopLeft,
-            5 | 6 => Self::BottomLeft,
-            7 | 8 => Self::Bottom,
+        let sector = (angle / DIRECTION_ANGLE_RAD) as i32;
+        match sector {
+            0 => Self::TopRight,
+            1 => Self::Top,
+            2 => Self::TopLeft,
+            3 => Self::BottomLeft,
+            4 => Self::Bottom,
             _ => Self::BottomRight,
         }
     }
@@ -524,6 +524,25 @@ impl Direction {
         match orientation {
             HexOrientation::Pointy => Self::from_pointy_angle_degrees(angle),
             HexOrientation::Flat => Self::from_flat_angle_degrees(angle),
+        }
+    }
+
+    #[must_use]
+    /// Returns the direction from the given `angle` in radians according the `orientation`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    ///
+    /// let angle = 0.6;
+    /// assert_eq!(Direction::from_angle(angle, &HexOrientation::Flat), Direction::TopRight);
+    /// assert_eq!(Direction::from_angle(angle, &HexOrientation::Pointy), Direction::Top);
+    /// ```
+    pub fn from_angle(angle: f32, orientation: &HexOrientation) -> Self {
+        match orientation {
+            HexOrientation::Pointy => Self::from_pointy_angle(angle),
+            HexOrientation::Flat => Self::from_flat_angle(angle),
         }
     }
 

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -434,8 +434,8 @@ impl Direction {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let direction = Direction::from_flat_angle_degrees(35.0);
-    /// assert_eq!(direction, Direction::TopRight);
+    /// let direction = Direction::from_pointy_angle_degrees(35.0);
+    /// assert_eq!(direction, Direction::Top);
     /// ```
     pub fn from_pointy_angle_degrees(angle: f32) -> Self {
         Self::from_flat_angle_degrees(angle + DIRECTION_ANGLE_OFFSET_DEGREES)
@@ -451,7 +451,7 @@ impl Direction {
     /// # use hexx::*;
     ///
     /// let direction = Direction::from_flat_angle_degrees(35.0);
-    /// assert_eq!(direction, Direction::Top);
+    /// assert_eq!(direction, Direction::TopRight);
     /// ```
     pub fn from_flat_angle_degrees(angle: f32) -> Self {
         let angle = angle % 360.0;
@@ -475,8 +475,8 @@ impl Direction {
     /// ```rust
     /// # use hexx::*;
     ///
-    /// let direction = Direction::from_flat_angle_degrees(0.6);
-    /// assert_eq!(direction, Direction::TopRight);
+    /// let direction = Direction::from_pointy_angle(0.6);
+    /// assert_eq!(direction, Direction::Top);
     /// ```
     pub fn from_pointy_angle(angle: f32) -> Self {
         Self::from_flat_angle(angle + DIRECTION_ANGLE_OFFSET_RAD)

--- a/src/direction/mod.rs
+++ b/src/direction/mod.rs
@@ -23,7 +23,7 @@ pub mod angles {
     use std::f32::consts::PI;
     /// Angle in radian between *flat* and *pointy* top orientations.
     /// Equivalent to 30 degrees
-    pub const DIRECTION_ANGLE_OFFSET: f32 = PI / 6.0;
+    pub const DIRECTION_ANGLE_OFFSET_RAD: f32 = PI / 6.0;
     /// Angle in radian between *flat* and *pointy* top orientations.
     /// Equivalent to π / 6 in radians
     pub const DIRECTION_ANGLE_OFFSET_DEGREES: f32 = 30.0;

--- a/src/direction/mod.rs
+++ b/src/direction/mod.rs
@@ -33,4 +33,6 @@ pub mod angles {
     /// Angle in degrees between two adjacent directions counter clockwise.
     /// Equivalent to π / 3 in radians
     pub const DIRECTION_ANGLE_DEGREES: f32 = 60.0;
+    /// π * 2
+    pub const PI_2: f32 = PI * 2.0;
 }

--- a/src/direction/tests.rs
+++ b/src/direction/tests.rs
@@ -191,6 +191,7 @@ mod hex_directions {
 }
 
 mod diagonal_direction {
+    use super::DiagonalDirection::*;
     use super::*;
 
     #[test]
@@ -230,6 +231,74 @@ mod diagonal_direction {
         for dir in DiagonalDirection::ALL_DIRECTIONS {
             let expected = dir.direction_ccw().angle_pointy_degrees() - 30.0;
             assert!(dir.angle_pointy_degrees() - expected <= EPSILON);
+        }
+    }
+
+    #[test]
+    fn direction_angle_from_to() {
+        for dir in DiagonalDirection::ALL_DIRECTIONS {
+            // degs
+            let flat_angle = dir.angle_flat_degrees();
+            assert_eq!(DiagonalDirection::from_flat_angle_degrees(flat_angle), dir);
+            let pointy_angle = dir.angle_pointy_degrees();
+            assert_eq!(
+                DiagonalDirection::from_pointy_angle_degrees(pointy_angle),
+                dir
+            );
+            // rads
+            let flat_angle = dir.angle_flat();
+            assert_eq!(DiagonalDirection::from_flat_angle(flat_angle), dir);
+            let pointy_angle = dir.angle_pointy();
+            assert_eq!(DiagonalDirection::from_pointy_angle(pointy_angle), dir);
+        }
+    }
+
+    #[test]
+    fn from_pointy_angles() {
+        let expected = |angle: f32| {
+            let angle = angle % 360.0;
+            let angle = if angle < 0.0 { angle + 360.0 } else { angle };
+            print!("pos angle = {angle}");
+            match angle {
+                v if v < 60.0 => TopRight,
+                v if v < 120.0 => TopLeft,
+                v if v < 180.0 => Left,
+                v if v < 240.0 => BottomLeft,
+                v if v < 300.0 => BottomRight,
+                _ => Right,
+            }
+        };
+        for angle in -1000..1000 {
+            let angle = angle as f32 + 0.1;
+            let angle_rad = angle.to_radians();
+            let expect = expected(angle);
+            println!("expect = {expect:?}, angle = {angle} ");
+            assert_eq!(DiagonalDirection::from_pointy_angle_degrees(angle), expect);
+            assert_eq!(DiagonalDirection::from_pointy_angle(angle_rad), expect);
+        }
+    }
+
+    #[test]
+    fn from_flat_angles() {
+        let expected = |angle: f32| {
+            let angle = angle % 360.0;
+            let angle = if angle < 0.0 { angle + 360.0 } else { angle };
+            match angle {
+                v if v < 30.0 => Right,
+                v if v < 90.0 => TopRight,
+                v if v < 150.0 => TopLeft,
+                v if v < 210.0 => Left,
+                v if v < 270.0 => BottomLeft,
+                v if v < 330.0 => BottomRight,
+                _ => Right,
+            }
+        };
+        for angle in -1000..1000 {
+            let angle = angle as f32 + 0.1;
+            let angle_rad = angle.to_radians();
+            let expect = expected(angle);
+            assert_eq!(DiagonalDirection::from_flat_angle_degrees(angle), expect);
+            assert_eq!(DiagonalDirection::from_flat_angle(angle_rad), expect);
         }
     }
 }

--- a/src/direction/tests.rs
+++ b/src/direction/tests.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::enum_glob_use)]
+#![allow(
+    clippy::enum_glob_use,
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss
+)]
 
 use super::*;
 use crate::HexOrientation;
@@ -66,6 +70,36 @@ mod hex_directions {
     }
 
     #[test]
+    fn from_flat_angles_degrees() {
+        let expected = |angle: f32| {
+            let angle = angle % 360.0;
+            let angle = if angle < 0.0 { angle + 360.0 } else { angle };
+            match angle {
+                v if v < 60.0 => TopRight,
+                v if v < 120.0 => Top,
+                v if v < 180.0 => TopLeft,
+                v if v < 240.0 => BottomLeft,
+                v if v < 300.0 => Bottom,
+                _ => BottomRight,
+            }
+        };
+        for angle in -1000..1000 {
+            let angle = angle as f32;
+            assert_eq!(Direction::from_flat_angle_degrees(angle), expected(angle));
+        }
+    }
+
+    #[test]
+    fn direction_angle_from_to() {
+        for dir in Direction::ALL_DIRECTIONS {
+            let flat_angle = dir.angle_flat_degrees();
+            assert_eq!(Direction::from_flat_angle_degrees(flat_angle), dir);
+            let pointy_angle = dir.angle_pointy_degrees();
+            assert_eq!(Direction::from_pointy_angle_degrees(pointy_angle), dir);
+        }
+    }
+
+    #[test]
     fn flat_angles_rad() {
         let expected = [
             (TopRight, PI / 6.0),
@@ -94,6 +128,27 @@ mod hex_directions {
         ];
         for (dir, angle) in expected {
             assert!(dir.angle_pointy_degrees() - angle <= EPSILON);
+        }
+    }
+
+    #[test]
+    fn from_pointy_angles_degrees() {
+        let expected = |angle: f32| {
+            let angle = angle % 360.0;
+            let angle = if angle < 0.0 { angle + 360.0 } else { angle };
+            match angle {
+                v if v < 30.0 => TopRight,
+                v if v < 90.0 => Top,
+                v if v < 150.0 => TopLeft,
+                v if v < 210.0 => BottomLeft,
+                v if v < 270.0 => Bottom,
+                v if v < 330.0 => BottomRight,
+                _ => TopRight,
+            }
+        };
+        for angle in -1000..1000 {
+            let angle = angle as f32;
+            assert_eq!(Direction::from_pointy_angle_degrees(angle), expected(angle));
         }
     }
 

--- a/src/direction/tests.rs
+++ b/src/direction/tests.rs
@@ -70,7 +70,7 @@ mod hex_directions {
     }
 
     #[test]
-    fn from_flat_angles_degrees() {
+    fn from_flat_angles() {
         let expected = |angle: f32| {
             let angle = angle % 360.0;
             let angle = if angle < 0.0 { angle + 360.0 } else { angle };
@@ -84,18 +84,27 @@ mod hex_directions {
             }
         };
         for angle in -1000..1000 {
-            let angle = angle as f32;
-            assert_eq!(Direction::from_flat_angle_degrees(angle), expected(angle));
+            let angle = angle as f32 + 0.1;
+            let angle_rad = angle.to_radians();
+            let expect = expected(angle);
+            assert_eq!(Direction::from_flat_angle_degrees(angle), expect);
+            assert_eq!(Direction::from_flat_angle(angle_rad), expect);
         }
     }
 
     #[test]
     fn direction_angle_from_to() {
         for dir in Direction::ALL_DIRECTIONS {
+            // degs
             let flat_angle = dir.angle_flat_degrees();
             assert_eq!(Direction::from_flat_angle_degrees(flat_angle), dir);
             let pointy_angle = dir.angle_pointy_degrees();
             assert_eq!(Direction::from_pointy_angle_degrees(pointy_angle), dir);
+            // rads
+            let flat_angle = dir.angle_flat();
+            assert_eq!(Direction::from_flat_angle(flat_angle), dir);
+            let pointy_angle = dir.angle_pointy();
+            assert_eq!(Direction::from_pointy_angle(pointy_angle), dir);
         }
     }
 
@@ -132,7 +141,7 @@ mod hex_directions {
     }
 
     #[test]
-    fn from_pointy_angles_degrees() {
+    fn from_pointy_angles() {
         let expected = |angle: f32| {
             let angle = angle % 360.0;
             let angle = if angle < 0.0 { angle + 360.0 } else { angle };
@@ -147,8 +156,11 @@ mod hex_directions {
             }
         };
         for angle in -1000..1000 {
-            let angle = angle as f32;
-            assert_eq!(Direction::from_pointy_angle_degrees(angle), expected(angle));
+            let angle = angle as f32 + 0.1;
+            let angle_rad = angle.to_radians();
+            let expect = expected(angle);
+            assert_eq!(Direction::from_pointy_angle_degrees(angle), expect);
+            assert_eq!(Direction::from_pointy_angle(angle_rad), expect);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@
 //! // Define your layout
 //! let layout = HexLayout {
 //!    hex_size: Vec2::new(1.0, 1.0),
-//!    orientation: HexOrientation::flat(),
+//!    orientation: HexOrientation::Flat,
 //!    ..Default::default()
 //! };
 //! // Get the hex coordinate at the world position `world_pos`.

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::direction::angles::DIRECTION_ANGLE_OFFSET;
+use crate::direction::angles::DIRECTION_ANGLE_OFFSET_RAD;
 use crate::Direction;
 
 const SQRT_3: f32 = 1.732_050_8;
@@ -9,7 +9,7 @@ const SQRT_3: f32 = 1.732_050_8;
 static POINTY_ORIENTATION: HexOrientationData = HexOrientationData {
     forward_matrix: [SQRT_3, SQRT_3 / 2.0, 0.0, 3.0 / 2.0],
     inverse_matrix: [SQRT_3 / 3.0, -1.0 / 3.0, 0.0, 2.0 / 3.0],
-    angle_offset: DIRECTION_ANGLE_OFFSET, // 30 degrees
+    angle_offset: DIRECTION_ANGLE_OFFSET_RAD, // 30 degrees
 };
 
 // TODO: make const


### PR DESCRIPTION
> Closes #84 

# Work done

* Added conversion from angles for both `Direction` and `DiagonalDirection` (#92):
  * `Direction::from_angle`
  * `Direction::from_pointy_angle`
  * `Direction::from_flat_angle`
  * `Direction::from_angle_degrees`
  * `Direction::from_pointy_angle_degrees`
  * `Direction::from_flat_angle_degrees`
  * `DiagonalDirection::from_angle`
  * `DiagonalDirection::from_pointy_angle`
  * `DiagonalDirection::from_flat_angle`
  * `DiagonalDirection::from_angle_degrees`
  * `DiagonalDirection::from_pointy_angle_degrees`
  * `DiagonalDirection::from_flat_angle_degrees`
  
# Extra work
  
* Added missing `Direction::angle_degrees` method (#92)
* Added missing `DiagonalDirection::angle_degrees` method (#92)
