### PR TITLE
HexOrientation as value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 * Added `UvOptions` for both planet and column mesh builder (#93):
   * `mesh_builder` example now uses a checker texture and showcases uv options
   * `ColumnMeshBuilder` has uv options for cap and side faces
+* (**BREAKING**) All functions taking a `HexOrientation` parameter no longer
+take a borrow (`&HexOrientation`) but a value (#95)
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@
 * Added `UvOptions` for both planet and column mesh builder (#93):
   * `mesh_builder` example now uses a checker texture and showcases uv options
   * `ColumnMeshBuilder` has uv options for cap and side faces
-* (**BREAKING**) All functions taking a `HexOrientation` parameter no longer
-take a borrow (`&HexOrientation`) but a value (#95)
+* (**BREAKING**) All functions that previously required a borrowed `&HexOrientation` 
+now take an owned `HexOrientation` as the type is now `Copy` (#95)
 * (**BREAKING**) Removed all functions deprecated in `0.6.0`
 
 ## 0.6.0

--- a/src/direction/diagonal_direction.rs
+++ b/src/direction/diagonal_direction.rs
@@ -407,7 +407,7 @@ impl DiagonalDirection {
     #[inline]
     #[must_use]
     /// Returns the angle in radians of the given direction in the given `orientation`
-    pub fn angle(self, orientation: &HexOrientation) -> f32 {
+    pub fn angle(self, orientation: HexOrientation) -> f32 {
         self.angle_pointy() - orientation.angle_offset
     }
 
@@ -416,7 +416,7 @@ impl DiagonalDirection {
     /// Returns the angle in degrees of the given direction according to its `orientation`
     ///
     /// See [`Self::angle`] for radians angles
-    pub fn angle_degrees(self, orientation: &HexOrientation) -> f32 {
+    pub fn angle_degrees(self, orientation: HexOrientation) -> f32 {
         match orientation {
             HexOrientation::Pointy => self.angle_pointy_degrees(),
             HexOrientation::Flat => self.angle_flat_degrees(),
@@ -514,10 +514,10 @@ impl DiagonalDirection {
     /// # use hexx::*;
     ///
     /// let angle = 15.0;
-    /// assert_eq!(DiagonalDirection::from_angle_degrees(angle, &HexOrientation::Flat), DiagonalDirection::Right);
-    /// assert_eq!(DiagonalDirection::from_angle_degrees(angle, &HexOrientation::Pointy), DiagonalDirection::TopRight);
+    /// assert_eq!(DiagonalDirection::from_angle_degrees(angle, HexOrientation::Flat), DiagonalDirection::Right);
+    /// assert_eq!(DiagonalDirection::from_angle_degrees(angle, HexOrientation::Pointy), DiagonalDirection::TopRight);
     /// ```
-    pub fn from_angle_degrees(angle: f32, orientation: &HexOrientation) -> Self {
+    pub fn from_angle_degrees(angle: f32, orientation: HexOrientation) -> Self {
         match orientation {
             HexOrientation::Pointy => Self::from_pointy_angle_degrees(angle),
             HexOrientation::Flat => Self::from_flat_angle_degrees(angle),
@@ -533,10 +533,10 @@ impl DiagonalDirection {
     /// # use hexx::*;
     ///
     /// let angle = 0.26;
-    /// assert_eq!(DiagonalDirection::from_angle(angle, &HexOrientation::Flat), DiagonalDirection::Right);
-    /// assert_eq!(DiagonalDirection::from_angle(angle, &HexOrientation::Pointy), DiagonalDirection::TopRight);
+    /// assert_eq!(DiagonalDirection::from_angle(angle, HexOrientation::Flat), DiagonalDirection::Right);
+    /// assert_eq!(DiagonalDirection::from_angle(angle, HexOrientation::Pointy), DiagonalDirection::TopRight);
     /// ```
-    pub fn from_angle(angle: f32, orientation: &HexOrientation) -> Self {
+    pub fn from_angle(angle: f32, orientation: HexOrientation) -> Self {
         match orientation {
             HexOrientation::Pointy => Self::from_pointy_angle(angle),
             HexOrientation::Flat => Self::from_flat_angle(angle),

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -392,7 +392,7 @@ impl Direction {
     #[inline]
     #[must_use]
     /// Returns the angle in radians of the given direction in the given `orientation`
-    pub fn angle(self, orientation: &HexOrientation) -> f32 {
+    pub fn angle(self, orientation: HexOrientation) -> f32 {
         self.angle_pointy() - orientation.angle_offset
     }
 
@@ -419,7 +419,7 @@ impl Direction {
     /// Returns the angle in degrees of the given direction according to its `orientation`
     ///
     /// See [`Self::angle`] for radians angles
-    pub fn angle_degrees(self, orientation: &HexOrientation) -> f32 {
+    pub fn angle_degrees(self, orientation: HexOrientation) -> f32 {
         match orientation {
             HexOrientation::Pointy => self.angle_pointy_degrees(),
             HexOrientation::Flat => self.angle_flat_degrees(),
@@ -515,10 +515,10 @@ impl Direction {
     /// # use hexx::*;
     ///
     /// let angle = 35.0;
-    /// assert_eq!(Direction::from_angle_degrees(angle, &HexOrientation::Flat), Direction::TopRight);
-    /// assert_eq!(Direction::from_angle_degrees(angle, &HexOrientation::Pointy), Direction::Top);
+    /// assert_eq!(Direction::from_angle_degrees(angle, HexOrientation::Flat), Direction::TopRight);
+    /// assert_eq!(Direction::from_angle_degrees(angle, HexOrientation::Pointy), Direction::Top);
     /// ```
-    pub fn from_angle_degrees(angle: f32, orientation: &HexOrientation) -> Self {
+    pub fn from_angle_degrees(angle: f32, orientation: HexOrientation) -> Self {
         match orientation {
             HexOrientation::Pointy => Self::from_pointy_angle_degrees(angle),
             HexOrientation::Flat => Self::from_flat_angle_degrees(angle),
@@ -534,10 +534,10 @@ impl Direction {
     /// # use hexx::*;
     ///
     /// let angle = 0.6;
-    /// assert_eq!(Direction::from_angle(angle, &HexOrientation::Flat), Direction::TopRight);
-    /// assert_eq!(Direction::from_angle(angle, &HexOrientation::Pointy), Direction::Top);
+    /// assert_eq!(Direction::from_angle(angle, HexOrientation::Flat), Direction::TopRight);
+    /// assert_eq!(Direction::from_angle(angle, HexOrientation::Pointy), Direction::Top);
     /// ```
-    pub fn from_angle(angle: f32, orientation: &HexOrientation) -> Self {
+    pub fn from_angle(angle: f32, orientation: HexOrientation) -> Self {
         match orientation {
             HexOrientation::Pointy => Self::from_pointy_angle(angle),
             HexOrientation::Flat => Self::from_flat_angle(angle),

--- a/src/direction/tests.rs
+++ b/src/direction/tests.rs
@@ -121,7 +121,7 @@ mod hex_directions {
         let orientation = HexOrientation::Flat;
         for (dir, angle) in expected {
             assert!(dir.angle_flat() - angle <= EPSILON);
-            assert!(dir.angle(&orientation) - angle <= EPSILON);
+            assert!(dir.angle(orientation) - angle <= EPSILON);
         }
     }
 
@@ -177,7 +177,7 @@ mod hex_directions {
         let orientation = HexOrientation::Pointy;
         for (dir, angle) in expected {
             assert!(dir.angle_pointy() - angle <= EPSILON);
-            assert!(dir.angle(&orientation) - angle <= EPSILON);
+            assert!(dir.angle(orientation) - angle <= EPSILON);
         }
     }
 

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -70,14 +70,14 @@ impl HexOrientation {
     #[must_use]
     #[inline]
     /// Computes the angle in radians of the given `direction` in the current orientation
-    pub fn direction_angle(&self, direction: Direction) -> f32 {
+    pub fn direction_angle(self, direction: Direction) -> f32 {
         direction.angle(self)
     }
 
     #[must_use]
     #[inline]
     /// Returns the orientation inner data, rotation angle and matrices
-    pub fn orientation_data(&self) -> &'static HexOrientationData {
+    pub fn orientation_data(self) -> &'static HexOrientationData {
         match self {
             Self::Pointy => &POINTY_ORIENTATION,
             Self::Flat => &FLAT_ORIENTATION,


### PR DESCRIPTION
> Closes #85 

All items taking a `HexOrientation` as a parameter now take it as value (`*`) instead of a borrow (`&`)