### PR TITLE
Mesh feature gate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,8 @@ jobs:
         run: cargo clippy --all --tests -- -D warnings
       - name: Run clippy all features check
         run: cargo clippy --all-features --all --tests -- -D warnings
+      - name: Run clippy no default features check
+        run: cargo clippy --no-default-features --all --tests -- -D warnings
 
   rustdoc:
     needs: [build, fmt]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Renamed `ser_de` feature to `serde`. The `ser_de` feature is still available
+* Added extra documentation to `MeshInfo`
+* Moved the mesh module under a `mesh` feature gate, enabled by default
+
 ## 0.7.0
 
 * Added `Hex::xrange` for excluding range coordinates (#88)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased]
 
-* Renamed `ser_de` feature to `serde`. The `ser_de` feature is still available
-* Added extra documentation to `MeshInfo`
-* Moved the mesh module under a `mesh` feature gate, enabled by default
+* Renamed `ser_de` feature to `serde`. The `ser_de` feature is still available (#99)
+* Added extra documentation to `MeshInfo` (#99)
+* Moved the mesh module under a `mesh` feature gate, enabled by default (#99)
 
 ## 0.7.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,17 @@ repository = "https://github.com/ManevilleF/hexx"
 exclude = [".github"]
 
 [features]
-default = ["algorithms"]
+default = ["algorithms", "mesh"]
 # HL algoritms
 algorithms = []
+# 3d Mesh features
+mesh = []
 # repr C
 packed = []
 # serde compatibility
-ser_de = ["serde", "glam/serde"]
+serde = ["dep:serde", "glam/serde"]
+# Old serde compat feature
+ser_de = ["serde"]
 
 [dependencies]
 glam = "0.23"

--- a/examples/mesh_builder.rs
+++ b/examples/mesh_builder.rs
@@ -39,12 +39,13 @@ pub fn main() {
         .register_type::<BuilderParams>()
         .init_resource::<BuilderParams>()
         .insert_resource(AmbientLight {
-            brightness: 0.1,
+            brightness: 0.3,
             ..default()
         })
         .add_plugins(DefaultPlugins)
         .add_plugin(WireframePlugin)
         .add_plugin(ResourceInspectorPlugin::<BuilderParams>::default())
+        .add_plugin(ResourceInspectorPlugin::<AmbientLight>::default())
         .add_startup_system(setup)
         .add_system(animate)
         .add_system(update_mesh)
@@ -65,6 +66,7 @@ fn setup(
         transform,
         ..default()
     });
+    let transform = Transform::from_xyz(20.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y);
     commands.spawn(DirectionalLightBundle {
         transform,
         ..default()

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -13,7 +13,7 @@ use crate::Hex;
 /// let bounds: HexBounds = iter.collect();
 /// ```
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HexBounds {
     /// bounds center
     pub center: Hex,

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -5,7 +5,7 @@ use crate::Hex;
 ///
 /// [doubled]: https://www.redblobgames.com/grids/hexagons/#coordinates-doubled
 #[derive(Debug, Clone, Copy, Default)]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DoubledHexMode {
     /// Doubles column values
     #[default]
@@ -19,7 +19,7 @@ pub enum DoubledHexMode {
 ///
 /// [offset]: https://www.redblobgames.com/grids/hexagons/#coordinates-offset
 #[derive(Debug, Clone, Copy, Default)]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum OffsetHexMode {
     /// Vertical layout, shoves even columns down
     EvenColumns,

--- a/src/direction/diagonal_direction.rs
+++ b/src/direction/diagonal_direction.rs
@@ -40,7 +40,7 @@ use crate::{Direction, HexOrientation};
 /// ```
 #[repr(u8)]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DiagonalDirection {
     #[default]
     /// Direction to (2, -1)

--- a/src/direction/hex_direction.rs
+++ b/src/direction/hex_direction.rs
@@ -43,7 +43,7 @@ use crate::{DiagonalDirection, HexOrientation};
 /// ```
 #[repr(u8)]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Direction {
     #[default]
     /// Direction to (1, -1)

--- a/src/hex_map.rs
+++ b/src/hex_map.rs
@@ -20,7 +20,7 @@ use crate::{Hex, HexBounds};
 ///
 /// [wraparound]: https://www.redblobgames.com/grids/hexagons/#wraparound
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HexMap {
     /// The bounds of the map
     bounds: HexBounds,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -23,7 +23,7 @@ use glam::Vec2;
 /// let hex_pos = layout.world_pos_to_hex(Vec2::new(1.23, 45.678));
 /// ```
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HexLayout {
     /// The hexagonal orientation of the layout (usually "flat" or "pointy")
     pub orientation: HexOrientation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@
 //! ### Cargo features
 //!
 //! `hexx` supports serialization and deserialization of most types using [serde](https://github.com/serde-rs/serde),
-//! through the `ser_de` feature gate. To enable it add the following line to your `Cargo.toml`:
+//! through the `serde` feature gate. To enable it add the following line to your `Cargo.toml`:
 //!
-//! - `hexx = { version = "0.7", features = ["ser_de"] }`
+//! - `hexx = { version = "0.7", features = ["serde"] }`
 //!
 //! By default `Hex` uses rust classic memory layout, if you want to use `hexx` through the FFI or
 //! have `Hex` be stored without any memory padding, the `packed` feature will make `Hex`
@@ -137,6 +137,7 @@ pub mod hex;
 pub mod hex_map;
 /// Hexagonal layout module
 pub mod layout;
+#[cfg(feature = "mesh")]
 /// Mesh generation utils module
 pub mod mesh;
 /// Hexagon oritentation module
@@ -144,7 +145,7 @@ pub mod orientation;
 /// Map shapes generation functions
 pub mod shapes;
 
-pub use glam::{IVec2, IVec3, Vec2, Vec3};
-pub use {
-    bounds::*, conversions::*, direction::*, hex::*, hex_map::*, layout::*, mesh::*, orientation::*,
-};
+pub use glam::{IVec2, IVec3, Quat, Vec2, Vec3};
+#[cfg(feature = "mesh")]
+pub use mesh::*;
+pub use {bounds::*, conversions::*, direction::*, hex::*, hex_map::*, layout::*, orientation::*};

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -41,6 +41,7 @@ pub(crate) const BASE_FACING: Vec3 = Vec3::Y;
 /// * [`ColumnMeshBuilder::at`]
 /// * [`PlaneMeshBuilder::at`]
 /// * [`Self::with_offset`] for a custom offset
+///
 /// Otherwise you might end up with meshes at the same coordinates
 pub struct MeshInfo {
     /// All vertices positions information (`Vertex_Position` attribute)

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -13,7 +13,35 @@ use crate::{Hex, HexLayout};
 pub(crate) const BASE_FACING: Vec3 = Vec3::Y;
 
 #[derive(Debug, Clone, Default)]
-/// Mesh information. The `const LEN` attribute ensures that there is the same number of vertices, normals and uvs
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// Hexagonal mesh information.
+///
+/// # Usage
+///
+/// Use:
+/// * [`ColumnMeshBuilder`] for 3d hexagonal column meshes
+/// * [`PlaneMeshBuilder`] for hexagonal plane meshes
+///
+/// The mesh info has some customization options:
+///
+/// ```rust
+/// # use hexx::*;
+///
+/// let layout = HexLayout::default();
+/// // Build the mesh info
+/// let info: MeshInfo = ColumnMeshBuilder::new(&layout, 2.0).build();
+/// // Customize the generated mesh
+/// let info = info.rotated(Quat::IDENTITY).with_offset(Vec3::new(12.0, 34.2, -43.54));
+/// ```
+///
+/// ## Merging
+///
+/// `MeshInfo` can be merged with other meshes using `Self::merge_with`.
+/// Don't forget to offset the meshes in the mesh builder using:
+/// * [`ColumnMeshBuilder::at`]
+/// * [`PlaneMeshBuilder::at`]
+/// * [`Self::with_offset`] for a custom offset
+/// Otherwise you might end up with meshes at the same coordinates
 pub struct MeshInfo {
     /// All vertices positions information (`Vertex_Position` attribute)
     pub vertices: Vec<Vec3>,

--- a/src/mesh/uv_mapping.rs
+++ b/src/mesh/uv_mapping.rs
@@ -1,7 +1,7 @@
 use glam::Vec2;
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Struct containing options for UV mapping.
 ///
 /// # Usage

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -29,7 +29,7 @@ static FLAT_ORIENTATION: HexOrientationData = HexOrientationData {
 /// let pointy = HexOrientation::pointy();
 /// ```
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HexOrientationData {
     /// Matrix used to compute hexagonal coordinates to world/pixel coordinates
     pub(crate) forward_matrix: [f32; 4],
@@ -41,7 +41,7 @@ pub struct HexOrientationData {
 
 /// Hexagonal orientation, either *Pointy-Topped* or *Flat-Topped*
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum HexOrientation {
     /// *Pointy* orientation, means that the hexagons are *pointy-topped*
     Pointy,


### PR DESCRIPTION
# Work done

* Renamed `ser_de` feature to `serde`. The `ser_de` feature is still available
* Added extra documentation to `MeshInfo`
* Moved the mesh module under a `mesh` feature gate, enabled by default