### PR TITLE
Fix for serde features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: build
         run: cargo build --verbose
+      - name: build with all features
+        run: cargo build --all-features --verbose
+      - name: build without default features
+        run: cargo build --no-default-features --verbose
 
   examples:
     needs: [build, fmt]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Renamed `ser_de` feature to `serde`. The `ser_de` feature is still available (#99)
 * Added extra documentation to `MeshInfo` (#99)
 * Moved the mesh module under a `mesh` feature gate, enabled by default (#99)
+* Fixed `serde` compilation error introduced in #99
 
 ## 0.7.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,6 @@ mesh = []
 packed = []
 # serde compatibility
 serde = ["dep:serde", "glam/serde"]
-# Old serde compat feature
-ser_de = ["serde"]
 
 [dependencies]
 glam = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ default = ["algorithms", "mesh"]
 # HL algoritms
 algorithms = []
 # 3d Mesh features
-mesh = []
+mesh = ["serde?/std"]
 # repr C
 packed = []
 # serde compatibility
 serde = ["dep:serde", "glam/serde"]
+# Old serde compat feature
+ser_de = ["serde"]
 
 [dependencies]
 glam = "0.23"

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@
  ### Cargo features
 
  `hexx` supports serialization and deserialization of most types using [serde](https://github.com/serde-rs/serde),
- through the `ser_de` feature gate. To enable it add the following line to your `Cargo.toml`:
+ through the `serde` feature gate. To enable it add the following line to your `Cargo.toml`:
 
- - `hexx = { version = "0.7", features = ["ser_de"] }`
+ - `hexx = { version = "0.7", features = ["serde"] }`
 
  By default `Hex` uses rust classic memory layout, if you want to use `hexx` through the FFI or
  have `Hex` be stored without any memory padding, the `packed` feature will make `Hex`

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -45,7 +45,7 @@ use std::cmp::{max, min};
 /// [axial]: https://www.redblobgames.com/grids/hexagons/#coordinates-axial
 #[derive(Copy, Clone, Default, Eq, PartialEq)]
 #[cfg_attr(not(target_arch = "spirv"), derive(Debug, Hash))]
-#[cfg_attr(feature = "ser_de", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "packed", repr(C))]
 pub struct Hex {
     /// `x` axial coordinate (sometimes called `q` or `i`)


### PR DESCRIPTION
#100 made me notice a problem with building `hex` with the `serde` feature. This PR Fixes the issue, coming from the missing `std` feature for `serde` if `mesh` is enabled