### PR TITLE
Hexagonal plane simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Reduced verteice and tri count of mesh generation (#119)
+
 ## 0.10.1
 
 * Use of built-in rust f32 consts instead of custom ones (#113)

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -124,7 +124,8 @@ impl MeshInfo {
         }
     }
 
-    /// Computes mesh data for an hexagonal plane facing `Vec3::Y`
+    /// Computes mesh data for an hexagonal plane facing `Vec3::Y` with 6
+    /// vertices and 4 triangles
     ///
     /// # Note
     ///
@@ -135,12 +136,10 @@ impl MeshInfo {
     /// * etc
     #[must_use]
     pub fn hexagonal_plane(layout: &HexLayout, hex: Hex) -> Self {
-        let center = layout.hex_to_world_pos(hex);
         let corners = layout.hex_corners(hex);
         let corners_arr = corners.map(|p| Vec3::new(p.x, 0., p.y));
         Self {
             vertices: vec![
-                Vec3::new(center.x, 0., center.y),
                 corners_arr[0],
                 corners_arr[1],
                 corners_arr[2],
@@ -149,16 +148,14 @@ impl MeshInfo {
                 corners_arr[5],
             ],
             uvs: vec![
-                center, corners[0], corners[1], corners[2], corners[3], corners[4], corners[5],
+                corners[0], corners[1], corners[2], corners[3], corners[4], corners[5],
             ],
-            normals: [Vec3::Y; 7].to_vec(),
+            normals: [Vec3::Y; 6].to_vec(),
             indices: vec![
-                1, 0, 2, // 1
-                2, 0, 3, // 2
-                3, 0, 4, // 3
-                4, 0, 5, // 4
-                5, 0, 6, // 5
-                6, 0, 1, // 6
+                0, 2, 1, // Top tri
+                3, 5, 4, // Bot tri
+                0, 5, 3, // Mid Quad
+                3, 2, 0, // Mid Quad
             ],
         }
     }

--- a/src/mesh/tests.rs
+++ b/src/mesh/tests.rs
@@ -19,7 +19,7 @@ fn mesh_integrity(mesh: MeshInfo, expected_len: usize) {
 #[test]
 fn plane_integrity() {
     let mesh = PlaneMeshBuilder::new(&HexLayout::default()).build();
-    mesh_integrity(mesh, 7);
+    mesh_integrity(mesh, 6);
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn column_integrity() {
     let mesh = ColumnMeshBuilder::new(&layout, 10.0)
         .without_bottom_face()
         .build();
-    mesh_integrity(mesh, 6 * 4 + 7);
+    mesh_integrity(mesh, 6 * 4 + 6);
     let mesh = ColumnMeshBuilder::new(&layout, 10.0).build();
-    mesh_integrity(mesh, 6 * 4 + 14);
+    mesh_integrity(mesh, 6 * 4 + 12);
 }


### PR DESCRIPTION
> Closes #118

# Work done

Optimized mesh generation for hexagonal planes, now using
- 4 triangles
- 6 vertices
Instead of:
- 6 triangles
- 7 vertices

Before:
<img width="161" alt="Screenshot 2023-10-17 at 09 59 24" src="https://github.com/ManevilleF/hexx/assets/26703856/c50407aa-b661-4e58-8ac9-33029d85969e">

After:
<img width="184" alt="Screenshot 2023-10-17 at 10 01 45" src="https://github.com/ManevilleF/hexx/assets/26703856/7780f07a-ad9a-4c66-a115-1e5c23401d48">