### PR TITLE
Mesh can be scaled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* Added `PlaneMeshBuilder::with_scale` option to scale generated mesh (#121)
+* Added `ColumnMeshBuilder::with_scale` option to scale generated mesh (#121)
+
 ## 0.11.0
 
 * Reduced vertice and tri count of mesh generation (#119)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## [Unreleased]
 
 * Added `PlaneMeshBuilder::with_scale` option to scale generated mesh (#121)
+* Added `PlaneMeshBuilder::with_rotation` option to rotate generated mesh (#121)
 * Added `ColumnMeshBuilder::with_scale` option to scale generated mesh (#121)
+* Added `ColumnMeshBuilder::with_rotation` option to rotate generated mesh (#121)
+* Mesh transformation follow the SRT order of operations (#121)
 
 ## 0.11.0
 

--- a/examples/3d_columns.rs
+++ b/examples/3d_columns.rs
@@ -75,8 +75,7 @@ fn setup_grid(
             let pos = layout.hex_to_world_pos(hex);
             let id = commands
                 .spawn(PbrBundle {
-                    transform: Transform::from_xyz(pos.x, hex.length() as f32 / 2.0, pos.y)
-                        .with_scale(Vec3::splat(0.9)),
+                    transform: Transform::from_xyz(pos.x, hex.length() as f32 / 2.0, pos.y),
                     mesh: mesh_handle.clone(),
                     material: default_material.clone(),
                     ..default()
@@ -124,6 +123,7 @@ fn animate_rings(
 fn hexagonal_column(hex_layout: &HexLayout) -> Mesh {
     let mesh_info = ColumnMeshBuilder::new(hex_layout, COLUMN_HEIGHT)
         .without_bottom_face()
+        .with_scale(Vec3::splat(0.9))
         .build();
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);

--- a/examples/a_star.rs
+++ b/examples/a_star.rs
@@ -71,7 +71,7 @@ fn setup_grid(
                 .spawn(ColorMesh2dBundle {
                     mesh: mesh.clone().into(),
                     material,
-                    transform: Transform::from_xyz(pos.x, pos.y, 0.0).with_scale(Vec3::splat(0.9)),
+                    transform: Transform::from_xyz(pos.x, pos.y, 0.0),
                     ..default()
                 })
                 .id();
@@ -151,7 +151,10 @@ fn handle_input(
 
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
-    let mesh_info = PlaneMeshBuilder::new(hex_layout).facing(Vec3::Z).build();
+    let mesh_info = PlaneMeshBuilder::new(hex_layout)
+        .facing(Vec3::Z)
+        .with_scale(Vec3::splat(0.9))
+        .build();
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);

--- a/examples/chunks.rs
+++ b/examples/chunks.rs
@@ -48,7 +48,7 @@ fn setup_grid(
         let hex_mod = hex.to_lower_res(CHUNK_SIZE);
         let color_index = (hex_mod.x - hex_mod.y).rem_euclid(3);
         commands.spawn(ColorMesh2dBundle {
-            transform: Transform::from_xyz(pos.x, pos.y, 0.0).with_scale(Vec3::splat(0.9)),
+            transform: Transform::from_xyz(pos.x, pos.y, 0.0),
             mesh: mesh_handle.clone().into(),
             material: materials[color_index as usize].clone(),
             ..default()
@@ -58,7 +58,10 @@ fn setup_grid(
 
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
-    let mesh_info = PlaneMeshBuilder::new(hex_layout).facing(Vec3::Z).build();
+    let mesh_info = PlaneMeshBuilder::new(hex_layout)
+        .with_scale(Vec3::splat(0.9))
+        .facing(Vec3::Z)
+        .build();
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);

--- a/examples/field_of_movement.rs
+++ b/examples/field_of_movement.rs
@@ -119,7 +119,7 @@ fn setup_grid(
                 .spawn(ColorMesh2dBundle {
                     mesh: mesh.clone().into(),
                     material,
-                    transform: Transform::from_xyz(pos.x, pos.y, 0.0).with_scale(Vec3::splat(1.)),
+                    transform: Transform::from_xyz(pos.x, pos.y, 0.0),
                     ..default()
                 })
                 .id();

--- a/examples/field_of_view.rs
+++ b/examples/field_of_view.rs
@@ -70,7 +70,7 @@ fn setup_grid(
                 .spawn(ColorMesh2dBundle {
                     mesh: mesh.clone().into(),
                     material,
-                    transform: Transform::from_xyz(pos.x, pos.y, 0.0).with_scale(Vec3::splat(0.9)),
+                    transform: Transform::from_xyz(pos.x, pos.y, 0.0),
                     ..default()
                 })
                 .id();
@@ -141,7 +141,10 @@ fn handle_input(
 
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
-    let mesh_info = PlaneMeshBuilder::new(hex_layout).facing(Vec3::Z).build();
+    let mesh_info = PlaneMeshBuilder::new(hex_layout)
+        .facing(Vec3::Z)
+        .with_scale(Vec3::splat(0.9))
+        .build();
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -81,7 +81,7 @@ fn setup_grid(
             let pos = layout.hex_to_world_pos(hex);
             let id = commands
                 .spawn(ColorMesh2dBundle {
-                    transform: Transform::from_xyz(pos.x, pos.y, 0.0).with_scale(Vec3::splat(0.95)),
+                    transform: Transform::from_xyz(pos.x, pos.y, 0.0),
                     mesh: mesh_handle.clone().into(),
                     material: default_material.clone(),
                     ..default()
@@ -199,7 +199,10 @@ fn handle_input(
 
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
-    let mesh_info = PlaneMeshBuilder::new(hex_layout).facing(Vec3::Z).build();
+    let mesh_info = PlaneMeshBuilder::new(hex_layout)
+        .facing(Vec3::Z)
+        .with_scale(Vec3::splat(0.95))
+        .build();
     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);

--- a/examples/merged_columns.rs
+++ b/examples/merged_columns.rs
@@ -94,7 +94,11 @@ fn setup_grid(
         // We compute the merged mesh with all children columns
         let mesh = children.fold(MeshInfo::default(), |mut mesh, c| {
             let [min, max] = settings.column_heights;
-            let height = rng.gen_range(min..=max);
+            let height = if min < max {
+                rng.gen_range(min..=max)
+            } else {
+                min
+            };
             let info = ColumnMeshBuilder::new(&layout, height)
                 .at(c)
                 .without_bottom_face()

--- a/examples/mesh_builder.rs
+++ b/examples/mesh_builder.rs
@@ -26,6 +26,7 @@ struct BuilderParams {
     pub bottom_face: bool,
     pub sides_uvs: UVOptions,
     pub caps_uvs: UVOptions,
+    pub scale: Vec3,
 }
 
 pub fn main() {
@@ -111,6 +112,7 @@ fn update_mesh(params: Res<BuilderParams>, info: Res<HexInfo>, mut meshes: ResMu
     let mut new_mesh = ColumnMeshBuilder::new(&info.layout, params.height)
         .with_subdivisions(params.subdivisions)
         .with_offset(Vec3::NEG_Y * params.height / 2.0)
+        .with_scale(params.scale)
         .with_caps_uv_options(params.caps_uvs.clone())
         .with_sides_uv_options(params.sides_uvs.clone());
     if !params.top_face {
@@ -144,6 +146,7 @@ impl Default for BuilderParams {
             bottom_face: true,
             sides_uvs: UVOptions::quad_default().with_scale_factor(vec2(1.0, 0.3)),
             caps_uvs: UVOptions::cap_default().with_scale_factor(vec2(0.5, 0.5)),
+            scale: Vec3::ONE,
         }
     }
 }

--- a/src/mesh/column_builder.rs
+++ b/src/mesh/column_builder.rs
@@ -31,7 +31,7 @@ use crate::{Hex, HexLayout, PlaneMeshBuilder, UVOptions};
 /// Transform operations (Scale, Rotate, Translate) through the methods
 ///
 /// - Scale: [`Self::with_scale`]
-/// - Rotate": [`Self::with_rotation`], [`Self::facing`]
+/// - Rotate: [`Self::with_rotation`], [`Self::facing`]
 /// - Translate: [`Self::with_offset`], [`Self::at`]
 ///
 /// Are executed in that order, or **SRT**
@@ -50,8 +50,6 @@ pub struct ColumnMeshBuilder<'l> {
     pub scale: Option<Vec3>,
     /// Optional rotation quaternion, useful to have the mesh already
     /// rotated
-    ///
-    /// Note that the `scale` factor will be applied before the rotation
     ///
     /// By default the mesh is *facing* up (**Y** axis)
     pub rotation: Option<Quat>,

--- a/src/mesh/column_builder.rs
+++ b/src/mesh/column_builder.rs
@@ -183,13 +183,14 @@ impl<'l> ColumnMeshBuilder<'l> {
             .with_uv_options(self.caps_uv_options)
             .build();
         // We store the offset to match the `self.pos`
-        let mut offset = self.layout.hex_to_world_pos(self.pos).extend(0.0);
+        let pos = self.layout.hex_to_world_pos(self.pos);
+        let mut offset = Vec3::new(pos.x, 0.0, pos.y);
         // We create the final mesh
         let mut mesh = MeshInfo::default();
         // Column sides
         let subidivisions = self.subdivisions.unwrap_or(0).max(1);
         let delta = self.height / subidivisions as f32;
-        let [a, b, c, d, e, f] = self.layout.hex_corners(self.pos);
+        let [a, b, c, d, e, f] = self.layout.hex_corners(Hex::ZERO);
         let corners = [[a, b], [b, c], [c, d], [d, e], [e, f], [f, a]];
         for [left, right] in corners {
             let normal = (left + right).normalize();

--- a/src/mesh/plane_builder.rs
+++ b/src/mesh/plane_builder.rs
@@ -91,7 +91,8 @@ impl<'l> PlaneMeshBuilder<'l> {
         // We compute the mesh at the origin to allow scaling
         let mut mesh = MeshInfo::hexagonal_plane(self.layout, Hex::ZERO);
         // We store the offset to match the `self.pos`
-        let mut offset = self.layout.hex_to_world_pos(self.pos).extend(0.0);
+        let pos = self.layout.hex_to_world_pos(self.pos);
+        let mut offset = Vec3::new(pos.x, 0.0, pos.y);
         // We apply optional scale
         if let Some(scale) = self.scale {
             mesh.vertices.iter_mut().for_each(|p| *p *= scale);

--- a/src/mesh/plane_builder.rs
+++ b/src/mesh/plane_builder.rs
@@ -12,7 +12,7 @@ use glam::{Quat, Vec3};
 /// Transform operations (Scale, Rotate, Translate) through the methods
 ///
 /// - Scale: [`Self::with_scale`]
-/// - Rotate": [`Self::with_rotation`], [`Self::facing`]
+/// - Rotate: [`Self::with_rotation`], [`Self::facing`]
 /// - Translate: [`Self::with_offset`], [`Self::at`]
 ///
 /// Are executed in that order, or **SRT**


### PR DESCRIPTION
> Closes #120 

# Work done

* Added `PlaneMeshBuilder::with_scale` option to scale generated mesh
* Added `ColumnMeshBuilder::with_scale` option to scale generated mesh

The scale factor is applied before the rotation and offset, and I don't know if the API is clear enough or if it's the right way to do it.
Maybe it should be called `local_scale` ?