### PR TITLE
Bevy 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added `ColumnMeshBuilder::with_scale` option to scale generated mesh (#121)
 * Added `ColumnMeshBuilder::with_rotation` option to rotate generated mesh (#121)
 * Mesh transformation follow the SRT order of operations (#121)
+* Bumped `bevy` deps to 0.12.x (#123)
 
 ## 0.11.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,14 +36,14 @@ features = ["derive"]
 optional = true
 
 [dependencies.bevy_reflect]
-version = "0.11"
+version = "0.12"
 default-features = false
 features = ["glam"]
 optional = true
 
 # For lib.rs doctests and examples
 [dev-dependencies.bevy]
-version = "0.11"
+version = "0.12"
 features = [
   "bevy_asset",
   "bevy_winit",
@@ -68,7 +68,7 @@ features = ["html_reports"]
 
 [dev-dependencies]
 rand = "0.8"
-bevy-inspector-egui = "0.20"
+bevy-inspector-egui = "0.21"
 
 [[example]]
 name = "hex_grid"

--- a/README.md
+++ b/README.md
@@ -210,12 +210,11 @@
  use hexx::MeshInfo;
 
  pub fn hexagonal_plane(mesh_info: MeshInfo) -> Mesh {
-     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-     mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-     mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-     mesh
+     Mesh::new(PrimitiveTopology::TriangleList)
+         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+         .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+         .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+         .with_indices(Some(Indices::U16(mesh_info.indices)))
  }
  ```
 

--- a/examples/3d_columns.rs
+++ b/examples/3d_columns.rs
@@ -125,10 +125,9 @@ fn hexagonal_column(hex_layout: &HexLayout) -> Mesh {
         .without_bottom_face()
         .with_scale(Vec3::splat(0.9))
         .build();
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-    mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-    mesh
+    Mesh::new(PrimitiveTopology::TriangleList)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+        .with_indices(Some(Indices::U16(mesh_info.indices)))
 }

--- a/examples/a_star.rs
+++ b/examples/a_star.rs
@@ -155,10 +155,9 @@ fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
         .facing(Vec3::Z)
         .with_scale(Vec3::splat(0.9))
         .build();
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-    mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-    mesh
+    Mesh::new(PrimitiveTopology::TriangleList)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+        .with_indices(Some(Indices::U16(mesh_info.indices)))
 }

--- a/examples/chunks.rs
+++ b/examples/chunks.rs
@@ -62,10 +62,9 @@ fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
         .with_scale(Vec3::splat(0.9))
         .facing(Vec3::Z)
         .build();
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-    mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-    mesh
+    Mesh::new(PrimitiveTopology::TriangleList)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+        .with_indices(Some(Indices::U16(mesh_info.indices)))
 }

--- a/examples/field_of_movement.rs
+++ b/examples/field_of_movement.rs
@@ -136,10 +136,9 @@ fn setup_grid(
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
     let mesh_info = PlaneMeshBuilder::new(hex_layout).facing(Vec3::Z).build();
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-    mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-    mesh
+    Mesh::new(PrimitiveTopology::TriangleList)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+        .with_indices(Some(Indices::U16(mesh_info.indices)))
 }

--- a/examples/field_of_view.rs
+++ b/examples/field_of_view.rs
@@ -145,10 +145,9 @@ fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
         .facing(Vec3::Z)
         .with_scale(Vec3::splat(0.9))
         .build();
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-    mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-    mesh
+    Mesh::new(PrimitiveTopology::TriangleList)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+        .with_indices(Some(Indices::U16(mesh_info.indices)))
 }

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -203,10 +203,9 @@ fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
         .facing(Vec3::Z)
         .with_scale(Vec3::splat(0.95))
         .build();
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-    mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-    mesh
+    Mesh::new(PrimitiveTopology::TriangleList)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+        .with_indices(Some(Indices::U16(mesh_info.indices)))
 }

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -91,7 +91,7 @@ fn setup_grid(
                         text: Text::from_section(
                             format!("{},{}", hex.x, hex.y),
                             TextStyle {
-                                font_size: 8.0,
+                                font_size: 7.0,
                                 color: Color::BLACK,
                                 ..default()
                             },

--- a/examples/merged_columns.rs
+++ b/examples/merged_columns.rs
@@ -124,12 +124,11 @@ fn setup_grid(
 
 /// Compute a bevy mesh from a hexx mesh
 fn hex_mesh(mesh_info: MeshInfo) -> Mesh {
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-    mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-    mesh
+    Mesh::new(PrimitiveTopology::TriangleList)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+        .with_indices(Some(Indices::U16(mesh_info.indices)))
 }
 
 impl Default for MapSettings {

--- a/examples/mesh_builder.rs
+++ b/examples/mesh_builder.rs
@@ -97,7 +97,7 @@ fn animate(
     time: Res<Time>,
 ) {
     if buttons.pressed(MouseButton::Left) {
-        for event in motion_evr.iter() {
+        for event in motion_evr.read() {
             let mut transform = transforms.get_mut(info.mesh_entity).unwrap();
             transform.rotate_y(event.delta.x * time.delta_seconds());
             transform.rotate_x(event.delta.y * time.delta_seconds());
@@ -129,12 +129,11 @@ fn update_mesh(params: Res<BuilderParams>, info: Res<HexInfo>, mut meshes: ResMu
 
 /// Compute a bevy mesh from the layout
 fn compute_mesh(mesh_info: MeshInfo) -> Mesh {
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-    mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-    mesh
+    Mesh::new(PrimitiveTopology::TriangleList)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+        .with_indices(Some(Indices::U16(mesh_info.indices)))
 }
 
 impl Default for BuilderParams {

--- a/examples/scroll_map.rs
+++ b/examples/scroll_map.rs
@@ -100,10 +100,9 @@ fn handle_input(
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
     let mesh_info = PlaneMeshBuilder::new(hex_layout).facing(Vec3::Z).build();
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-    mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-    mesh
+    Mesh::new(PrimitiveTopology::TriangleList)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+        .with_indices(Some(Indices::U16(mesh_info.indices)))
 }

--- a/examples/wrap_map.rs
+++ b/examples/wrap_map.rs
@@ -109,10 +109,9 @@ fn handle_input(
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
     let mesh_info = PlaneMeshBuilder::new(hex_layout).facing(Vec3::Z).build();
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-    mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-    mesh
+    Mesh::new(PrimitiveTopology::TriangleList)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+        .with_indices(Some(Indices::U16(mesh_info.indices)))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,12 +197,11 @@
 //! use hexx::MeshInfo;
 //!
 //! pub fn hexagonal_plane(mesh_info: MeshInfo) -> Mesh {
-//!     let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-//!     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices);
-//!     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals);
-//!     mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs);
-//!     mesh.set_indices(Some(Indices::U16(mesh_info.indices)));
-//!     mesh
+//!     Mesh::new(PrimitiveTopology::TriangleList)
+//!         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
+//!         .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)
+//!         .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, mesh_info.uvs)
+//!         .with_indices(Some(Indices::U16(mesh_info.indices)))
 //! }
 //! ```
 //!


### PR DESCRIPTION
- [x] Bump bevy dependencies to 0.12

`hex_grid` example does not show text correctly due to https://github.com/bevyengine/bevy/issues/10407