### PR TITLE
Experimental SIMD support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ nodes instead of one, allowing for more use cases (#130, #128)
 * Bumped `bevy_inspector_egui` dependency (#129)
 * Added a `sprite_sheet` bevy example (#135)
 * Added `HexLayout::rect_size` method (#135)
+* (**BREAKING**) Dropped legacy `ser_de` feature, use `serde` insted
+* Added new methods for `Hex` iterators:
+  * `min` which computes the minimum value
+  * `max` which computes the max value
+* Added experimental SIMD support behind `simd` feature:
+  * The `Sum` implementation will use SIMD
+  * Added the following functions:
+    * `Hex::simd_add4`
+    * `Hex::simd_add8`
+    * `Hex::simd_min4`
+    * `Hex::simd_min8`
+    * `Hex::simd_max4`
+    * `Hex::simd_max8`
 
 ## 0.12.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ mesh = ["serde?/std"]
 packed = []
 # serde compatibility
 serde = ["dep:serde", "glam/serde"]
-# Old serde compat feature
-ser_de = ["serde"]
+# Experimental simd support
+simd = ["dep:wide"]
 # Adds Bevy Reflection support
 bevy_reflect = ["dep:bevy_reflect"]
 
@@ -39,6 +39,10 @@ optional = true
 version = "0.12"
 default-features = false
 features = ["glam"]
+optional = true
+
+[dependencies.wide]
+version = "0.7"
 optional = true
 
 # For lib.rs doctests and examples
@@ -131,6 +135,11 @@ harness = false
 [[bench]]
 name = "rings"
 harness = false
+
+[[bench]]
+name = "simd"
+harness = false
+required-features = ["simd"]
 
 [profile.dev]
 opt-level = 1

--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@
 
  ### Cargo features
 
+ * `serde`
+
  `hexx` supports serialization and deserialization of most types using [serde](https://github.com/serde-rs/serde),
  through the `serde` feature gate. To enable it add the following line to
  your `Cargo.toml`:
 
  - `hexx = { version = "0.12", features = ["serde"] }`
+
+ * `packed`
 
  By default `Hex` uses rust classic memory layout, if you want to use `hexx`
  through the FFI or have `Hex` be stored without any memory padding, the
@@ -49,6 +53,32 @@
  following line to your `Cargo.toml`:
 
  - `hexx = { version = "0.12", features = ["packed"] }`
+
+ * `algorithms`
+
+ > Enabled by default
+
+ Enables the `algorithms` module containing basic implementation of
+ pathfinding algorithms
+
+ - `hexx = { version = "0.12", features = ["algorithms"]}`
+
+ * `mesh`
+
+ > Enabled by default
+
+ Enables the `mesh` module containing the mesh builder types, to construct
+ procedural hexagon planes and columns
+
+ - `hexx = { version = "0.12", features = ["mesh"] }`
+
+ * `simd` (**Experimental**)
+
+ Enables simd operations using the [wide](https://docs.rs/wide/latest/wide/index.html) crate
+
+ - `hexx = { version = "0.12", features = ["simd"] }`
+
+ * `bevy_reflect`
 
  `hexx` supports [Bevy Reflection](https://docs.rs/bevy_reflect/latest/bevy_reflect) through the
  `bevy_reflect` feature. To enable it add the following line to your

--- a/benches/simd.rs
+++ b/benches/simd.rs
@@ -1,0 +1,21 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use hexx::*;
+
+pub fn sum_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Hex Sum");
+    group.significance_level(0.1).sample_size(100);
+    let range: u32 = 1000;
+
+    group.bench_with_input(
+        BenchmarkId::new("Regular Sum", range),
+        &range,
+        |b, range| b.iter(|| Hex::ZERO.range(*range).fold(Hex::ZERO, |a, b| a + b)),
+    );
+    group.bench_with_input(BenchmarkId::new("SIMD Sum", range), &range, |b, range| {
+        b.iter(|| Hex::ZERO.range(*range).sum::<Hex>())
+    });
+    group.finish();
+}
+
+criterion_group!(benches, sum_benchmark);
+criterion_main!(benches);

--- a/src/hex/iter.rs
+++ b/src/hex/iter.rs
@@ -2,6 +2,34 @@ use crate::{Hex, HexBounds};
 
 /// Extension trait for iterators of [`Hex`]
 pub trait HexIterExt: Iterator {
+    /// Method which takes an iterator and finds the min value according to
+    /// [`Hex::min`]
+    ///
+    /// This method will return `None` on an empty iterator
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let max = Hex::ZERO.range(10).min();
+    /// assert_eq!(max, hex(-10, -10));
+    /// ```
+    fn min(self) -> Option<Hex>;
+
+    /// Method which takes an iterator and finds the max value according to
+    /// [`Hex::max`]
+    ///
+    /// This method will return `None` on an empty iterator
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use hexx::*;
+    /// let max = Hex::ZERO.range(10).max();
+    /// assert_eq!(max, hex(10, 10));
+    /// ```
+    fn max(self) -> Option<Hex>;
+
     /// Method which takes an iterator and finds the mean (average) value.
     ///
     /// This method will return [`Hex::ZERO`] on an empty iterator
@@ -65,6 +93,14 @@ impl<I: Iterator<Item = Hex>> HexIterExt for I {
 
     fn bounds(self) -> HexBounds {
         self.collect()
+    }
+
+    fn min(self) -> Option<Hex> {
+        self.reduce(Hex::min)
+    }
+
+    fn max(self) -> Option<Hex> {
+        self.reduce(Hex::max)
     }
 }
 

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -7,6 +7,9 @@ mod impls;
 mod iter;
 /// Hex ring utils
 mod rings;
+#[cfg(feature = "simd")]
+/// simd operations
+mod simd;
 /// swizzle utils
 mod siwzzle;
 #[cfg(test)]

--- a/src/hex/simd.rs
+++ b/src/hex/simd.rs
@@ -1,0 +1,31 @@
+#![allow(clippy::many_single_char_names)]
+use super::Hex;
+use wide::{i32x4, i32x8};
+
+macro_rules! simd_op {
+    ($name:ident, $num:expr, $vec_type:ident, $op:ident, $op_name:expr) => {
+        impl Hex {
+            #[doc = concat!("Performs a ", stringify!($op_name), " over all `vals` coordinates using SIMD instructions if possible. Operates on ", stringify!($num), " elements.")]
+            #[must_use]
+            pub fn $name(vals: [Self; $num]) -> Self {
+                let x_values = vals.map(|h| h.x);
+                let y_values = vals.map(|h| h.y);
+                let x = $vec_type::new(x_values).$op();
+                let y = $vec_type::new(y_values).$op();
+                Self::new(x, y)
+            }
+        }
+    };
+}
+
+// Usage for sum
+simd_op!(simd_sum4, 4, i32x4, reduce_add, "sum");
+simd_op!(simd_sum8, 8, i32x8, reduce_add, "sum");
+
+// Usage for min
+simd_op!(simd_min4, 4, i32x4, reduce_min, "min");
+simd_op!(simd_min8, 8, i32x8, reduce_min, "min");
+
+// Usage for max
+simd_op!(simd_max4, 4, i32x4, reduce_max, "max");
+simd_op!(simd_max8, 8, i32x8, reduce_max, "max");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,15 @@
 //!
 //! ### Cargo features
 //!
+//! * `serde`
+//!
 //! `hexx` supports serialization and deserialization of most types using [serde](https://github.com/serde-rs/serde),
 //! through the `serde` feature gate. To enable it add the following line to
 //! your `Cargo.toml`:
 //!
 //! - `hexx = { version = "0.12", features = ["serde"] }`
+//!
+//! * `packed`
 //!
 //! By default `Hex` uses rust classic memory layout, if you want to use `hexx`
 //! through the FFI or have `Hex` be stored without any memory padding, the
@@ -36,6 +40,32 @@
 //! following line to your `Cargo.toml`:
 //!
 //! - `hexx = { version = "0.12", features = ["packed"] }`
+//!
+//! * `algorithms`
+//!
+//! > Enabled by default
+//!
+//! Enables the `algorithms` module containing basic implementation of
+//! pathfinding algorithms
+//!
+//! - `hexx = { version = "0.12", features = ["algorithms"]}`
+//!
+//! * `mesh`
+//!
+//! > Enabled by default
+//!
+//! Enables the `mesh` module containing the mesh builder types, to construct
+//! procedural hexagon planes and columns
+//!
+//! - `hexx = { version = "0.12", features = ["mesh"] }`
+//!
+//! * `simd` (**Experimental**)
+//!
+//! Enables simd operations using the [wide](https://docs.rs/wide/latest/wide/index.html) crate
+//!
+//! - `hexx = { version = "0.12", features = ["simd"] }`
+//!
+//! * `bevy_reflect`
 //!
 //! `hexx` supports [Bevy Reflection](https://docs.rs/bevy_reflect/latest/bevy_reflect) through the
 //! `bevy_reflect` feature. To enable it add the following line to your


### PR DESCRIPTION
> Addresses #59 

## Work done:

### SIMD

* Added experimental SIMD support behind `simd` feature:
  * The `Sum` implementation will use SIMD
  * Added the following functions:
    * `Hex::simd_add4`
    * `Hex::simd_add8`
    * `Hex::simd_min4`
    * `Hex::simd_min8`
    * `Hex::simd_max4`
    * `Hex::simd_max8`
    
### Other

* Dropped legacy `ser_de` feature, use `serde` insted
* Added new methods for `Hex` iterators:
  * `min` which computes the minimum value
  * `max` which computes the max value
  
## Thoughts

I added a benchmark that shows that the SIMD sum is **slower** than a regular sum in `release` mode. So either my Mac is not supported by `wide` simd operations and is falling back to regular slower sums, or I'm using the crate wrong.

Also the `min`/ `max` methods are not using SIMD at all, `wide` provides them but the implementation is not using simd optimizations.

I'm not sure that it's worth it.