### PR TITLE
Center aligned meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ nodes instead of one, allowing for more use cases (#130, #128)
 * Bumped `bevy_inspector_egui` dependency (#129)
 * Added a `sprite_sheet` bevy example (#135)
 * Added `HexLayout::rect_size` method (#135)
+* Added `ColumnMeshBuilder::center_aligned` option (#139)
+* Added `PlaneMeshBuilder::center_aligned` option (#139)
 
 ## 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ nodes instead of one, allowing for more use cases (#130, #128)
 * Added `HexLayout::rect_size` method (#135)
 * Added `ColumnMeshBuilder::center_aligned` option (#139)
 * Added `PlaneMeshBuilder::center_aligned` option (#139)
+* Deprecated `MeshInfo::hexagonal_plane` in favor of `PlaneMeshBuilder` (#139)
 
 ## 0.12.0
 

--- a/examples/3d_columns.rs
+++ b/examples/3d_columns.rs
@@ -124,6 +124,7 @@ fn hexagonal_column(hex_layout: &HexLayout) -> Mesh {
     let mesh_info = ColumnMeshBuilder::new(hex_layout, COLUMN_HEIGHT)
         .without_bottom_face()
         .with_scale(Vec3::splat(0.9))
+        .center_aligned()
         .build();
     Mesh::new(PrimitiveTopology::TriangleList)
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)

--- a/examples/a_star.rs
+++ b/examples/a_star.rs
@@ -154,6 +154,7 @@ fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
     let mesh_info = PlaneMeshBuilder::new(hex_layout)
         .facing(Vec3::Z)
         .with_scale(Vec3::splat(0.9))
+        .center_aligned()
         .build();
     Mesh::new(PrimitiveTopology::TriangleList)
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)

--- a/examples/chunks.rs
+++ b/examples/chunks.rs
@@ -61,6 +61,7 @@ fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
     let mesh_info = PlaneMeshBuilder::new(hex_layout)
         .with_scale(Vec3::splat(0.9))
         .facing(Vec3::Z)
+        .center_aligned()
         .build();
     Mesh::new(PrimitiveTopology::TriangleList)
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)

--- a/examples/field_of_movement.rs
+++ b/examples/field_of_movement.rs
@@ -87,7 +87,6 @@ fn setup_grid(
 ) {
     let layout = HexLayout {
         hex_size: HEX_SIZE,
-        origin: (50.0, -40.0).into(),
         ..default()
     };
     let mesh = meshes.add(hexagonal_plane(&layout));

--- a/examples/field_of_movement.rs
+++ b/examples/field_of_movement.rs
@@ -87,6 +87,7 @@ fn setup_grid(
 ) {
     let layout = HexLayout {
         hex_size: HEX_SIZE,
+        origin: (50.0, -40.0).into(),
         ..default()
     };
     let mesh = meshes.add(hexagonal_plane(&layout));
@@ -135,7 +136,10 @@ fn setup_grid(
 
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
-    let mesh_info = PlaneMeshBuilder::new(hex_layout).facing(Vec3::Z).build();
+    let mesh_info = PlaneMeshBuilder::new(hex_layout)
+        .facing(Vec3::Z)
+        .center_aligned()
+        .build();
     Mesh::new(PrimitiveTopology::TriangleList)
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
         .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)

--- a/examples/field_of_view.rs
+++ b/examples/field_of_view.rs
@@ -48,7 +48,6 @@ fn setup_grid(
 ) {
     let layout = HexLayout {
         hex_size: HEX_SIZE,
-        origin: (50.0, -40.0).into(),
         ..default()
     };
     let mesh = meshes.add(hexagonal_plane(&layout));

--- a/examples/field_of_view.rs
+++ b/examples/field_of_view.rs
@@ -48,6 +48,7 @@ fn setup_grid(
 ) {
     let layout = HexLayout {
         hex_size: HEX_SIZE,
+        origin: (50.0, -40.0).into(),
         ..default()
     };
     let mesh = meshes.add(hexagonal_plane(&layout));
@@ -144,6 +145,7 @@ fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
     let mesh_info = PlaneMeshBuilder::new(hex_layout)
         .facing(Vec3::Z)
         .with_scale(Vec3::splat(0.9))
+        .center_aligned()
         .build();
     Mesh::new(PrimitiveTopology::TriangleList)
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -62,7 +62,6 @@ fn setup_grid(
 ) {
     let layout = HexLayout {
         hex_size: HEX_SIZE,
-        origin: (50.0, -40.0).into(),
         ..default()
     };
     // materials

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -62,6 +62,7 @@ fn setup_grid(
 ) {
     let layout = HexLayout {
         hex_size: HEX_SIZE,
+        origin: (50.0, -40.0).into(),
         ..default()
     };
     // materials
@@ -202,6 +203,7 @@ fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
     let mesh_info = PlaneMeshBuilder::new(hex_layout)
         .facing(Vec3::Z)
         .with_scale(Vec3::splat(0.95))
+        .center_aligned()
         .build();
     Mesh::new(PrimitiveTopology::TriangleList)
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)

--- a/examples/merged_columns.rs
+++ b/examples/merged_columns.rs
@@ -102,6 +102,7 @@ fn setup_grid(
             let info = ColumnMeshBuilder::new(&layout, height)
                 .at(c)
                 .without_bottom_face()
+                .center_aligned()
                 .build();
             mesh.merge_with(info);
             mesh

--- a/examples/scroll_map.rs
+++ b/examples/scroll_map.rs
@@ -99,7 +99,10 @@ fn handle_input(
 
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
-    let mesh_info = PlaneMeshBuilder::new(hex_layout).facing(Vec3::Z).build();
+    let mesh_info = PlaneMeshBuilder::new(hex_layout)
+        .facing(Vec3::Z)
+        .center_aligned()
+        .build();
     Mesh::new(PrimitiveTopology::TriangleList)
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
         .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)

--- a/examples/wrap_map.rs
+++ b/examples/wrap_map.rs
@@ -108,7 +108,10 @@ fn handle_input(
 
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
-    let mesh_info = PlaneMeshBuilder::new(hex_layout).facing(Vec3::Z).build();
+    let mesh_info = PlaneMeshBuilder::new(hex_layout)
+        .facing(Vec3::Z)
+        .center_aligned()
+        .build();
     Mesh::new(PrimitiveTopology::TriangleList)
         .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, mesh_info.vertices)
         .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, mesh_info.normals)

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -108,6 +108,15 @@ impl HexLayout {
                 HexOrientation::Flat => Vec2::new(2.0, SQRT_3),
             }
     }
+
+    /// Consumes `self` and returns a new layout with an `origin` set to (0.0,
+    /// 0.0)
+    pub(crate) const fn no_offset(self) -> Self {
+        Self {
+            origin: Vec2::ZERO,
+            ..self
+        }
+    }
 }
 
 impl Default for HexLayout {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -52,17 +52,21 @@ pub struct HexLayout {
 }
 
 impl HexLayout {
-    #[allow(clippy::cast_precision_loss)]
     #[must_use]
     /// Computes hexagonal coordinates `hex` into world/pixel coordinates
     pub fn hex_to_world_pos(&self, hex: Hex) -> Vec2 {
+        self.hex_to_center_aligned_world_pos(hex) + self.origin
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    #[must_use]
+    pub(crate) fn hex_to_center_aligned_world_pos(&self, hex: Hex) -> Vec2 {
         let matrix = self.orientation.forward_matrix;
         Vec2::new(
             matrix[0].mul_add(hex.x() as f32, matrix[1] * hex.y() as f32),
             matrix[2].mul_add(hex.x() as f32, matrix[3] * hex.y() as f32),
         ) * self.hex_size
             * self.axis_scale()
-            + self.origin
     }
 
     #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
@@ -77,15 +81,19 @@ impl HexLayout {
         ])
     }
 
-    #[allow(clippy::cast_precision_loss)]
     #[must_use]
     /// Retrieves all 6 corner coordinates of the given hexagonal coordinates
     /// `hex`
     pub fn hex_corners(&self, hex: Hex) -> [Vec2; 6] {
         let center = self.hex_to_world_pos(hex);
+        self.center_aligned_hex_corners().map(|c| c + center)
+    }
+
+    #[must_use]
+    pub(crate) fn center_aligned_hex_corners(&self) -> [Vec2; 6] {
         Direction::ALL_DIRECTIONS.map(|dir| {
             let angle = dir.angle_pointy() + self.orientation.angle_offset;
-            center + Vec2::new(self.hex_size.x * angle.cos(), self.hex_size.y * angle.sin())
+            Vec2::new(self.hex_size.x * angle.cos(), self.hex_size.y * angle.sin())
         })
     }
 
@@ -107,15 +115,6 @@ impl HexLayout {
                 HexOrientation::Pointy => Vec2::new(SQRT_3, 2.0),
                 HexOrientation::Flat => Vec2::new(2.0, SQRT_3),
             }
-    }
-
-    /// Consumes `self` and returns a new layout with an `origin` set to (0.0,
-    /// 0.0)
-    pub(crate) const fn no_offset(self) -> Self {
-        Self {
-            origin: Vec2::ZERO,
-            ..self
-        }
     }
 }
 

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -135,8 +135,35 @@ impl MeshInfo {
     /// * rotation
     /// * etc
     #[must_use]
+    #[deprecated(since = "0.13.0", note = "Use `PlaneMeshBuilder` instead")]
     pub fn hexagonal_plane(layout: &HexLayout, hex: Hex) -> Self {
         let corners = layout.hex_corners(hex);
+        let corners_arr = corners.map(|p| Vec3::new(p.x, 0., p.y));
+        Self {
+            vertices: vec![
+                corners_arr[0],
+                corners_arr[1],
+                corners_arr[2],
+                corners_arr[3],
+                corners_arr[4],
+                corners_arr[5],
+            ],
+            uvs: vec![
+                corners[0], corners[1], corners[2], corners[3], corners[4], corners[5],
+            ],
+            normals: [Vec3::Y; 6].to_vec(),
+            indices: vec![
+                0, 2, 1, // Top tri
+                3, 5, 4, // Bot tri
+                0, 5, 3, // Mid Quad
+                3, 2, 0, // Mid Quad
+            ],
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn center_aligned_hexagonal_plane(layout: &HexLayout) -> Self {
+        let corners = layout.center_aligned_hex_corners();
         let corners_arr = corners.map(|p| Vec3::new(p.x, 0., p.y));
         Self {
             vertices: vec![


### PR DESCRIPTION
> Closes #136 

## What does it solve

- [x] Mesh generation was broken if used with an `HexLayout` with a non zero `origin`, as the origin offset would be applied twice ( `hexagonal_plane` + the mesh builders)
- [x] In addition to this, if used with `bevy` the offset would be also applied by hexagon entities transforms

## Solution

* Added a `center_aligned` builder method to all mesh builders. this negates the `HexLayout` offset
* Fixed `PlaneMeshBuilder::build` method which was applying the offset twice