### PR TITLE
Feat/mesh insetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+* Removed methods deprecated in previous versions
+* Added new `MeshInfo` methods:
+  * `with_scale`
+  * `centroid`
+  * `uv_centroid`
+* (**BREAKING**) Changed the way `ColumnMeshBuilder` generates quad to be consistent
+with hexagonal faces
+* Fixed the way `ColumnMeshBuilder` generate the hexagonal caps, which could behave
+strangely with non center aligned layout
+
 ## 0.15.0
 
 * Bumped `bevy`, `bevy_egui` and `bevy_inspector_egui` dev dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Added new `MeshInfo` methods:
   * `with_scale`
+  * `with_uv_scale`
   * `centroid`
   * `uv_centroid`
 * (**BREAKING**) Changed the way `ColumnMeshBuilder` generates quad to be consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,25 @@
 ## [Unreleased]
 
 * Removed methods deprecated in previous versions
+
+### Mesh generation overhaul
+
 * Added new `MeshInfo` methods:
   * `with_scale`
   * `centroid`
   * `uv_centroid`
 * (**BREAKING**) Changed the way `ColumnMeshBuilder` generates quad to be consistent
 with hexagonal faces
+* (**BREAKING**) Changed inner `ColumnMeshBuilder` fields, but the builder API was
+kept consistent
 * Fixed the way `ColumnMeshBuilder` generate the hexagonal caps, which could behave
 strangely with non center aligned layout
+* Added a `mesh::utils` modules for primitive shape management
+* Added `ColumnMeshBuilder::with_sides_uv_options_fn` for block based options setting
+* Added mesh insetting options:
+  * `ColumnMeshBuilder::with_caps_inset_options` to inset the column hexagonal faces
+  * `ColumnMeshBuilder::with_sides_inset_options` to inset the column side quads
+  * `PlaneMeshBuilder::with_inset_options` to inset the hexagonal face
 
 ## 0.15.0
 

--- a/examples/mesh_builder.rs
+++ b/examples/mesh_builder.rs
@@ -104,7 +104,8 @@ fn show_ui(world: &mut World) {
                             if ui.button("Enable").clicked() {
                                 params.caps_inset = Some(InsetOptions {
                                     keep_inner_face: true,
-                                    mode: InsetMode::Scale(0.2),
+                                    scale: 0.2,
+                                    mode: InsetScaleMode::default(),
                                 })
                             }
                         }
@@ -145,7 +146,8 @@ fn show_ui(world: &mut World) {
                         if ui.button("Enable").clicked() {
                             params.sides_inset = Some(InsetOptions {
                                 keep_inner_face: true,
-                                mode: InsetMode::Scale(0.2),
+                                scale: 0.2,
+                                mode: InsetScaleMode::default(),
                             })
                         }
                     }

--- a/examples/mesh_builder.rs
+++ b/examples/mesh_builder.rs
@@ -14,6 +14,7 @@ struct HexInfo {
     pub layout: HexLayout,
     pub mesh_entity: Entity,
     pub mesh_handle: Handle<Mesh>,
+    pub material_handle: Handle<StandardMaterial>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -39,8 +40,10 @@ struct BuilderParams {
     pub bottom_face: bool,
     pub scale: Vec3,
     pub sides_uvs_mode: SideUVMode,
+    pub sides_inset: Option<InsetOptions>,
     pub sides_uvs: [UVOptions; 6],
     pub caps_uvs: UVOptions,
+    pub caps_inset: Option<InsetOptions>,
 }
 
 pub fn main() {
@@ -85,32 +88,96 @@ fn show_ui(world: &mut World) {
                 ui.end_row();
             });
             ui.separator();
-            ui.heading("Caps UV options");
-            bevy_inspector::ui_for_value(&mut params.caps_uvs, ui, world);
-            ui.separator();
-            ui.heading("Sides UV options");
-            ui.horizontal(|ui| {
-                egui::ComboBox::from_id_source("Side Uv mode")
-                    .selected_text(params.sides_uvs_mode.label())
-                    .show_ui(ui, |ui| {
-                        let option = SideUVMode::Global;
-                        ui.selectable_value(&mut params.sides_uvs_mode, option, option.label());
-                        let option = SideUVMode::Multi;
-                        ui.selectable_value(&mut params.sides_uvs_mode, option, option.label());
-                    })
-            });
-            egui::ScrollArea::vertical().show(ui, |ui| match params.sides_uvs_mode {
-                SideUVMode::Global => {
-                    if bevy_inspector::ui_for_value(&mut params.sides_uvs[0], ui, world) {
-                        params.sides_uvs = [params.sides_uvs[0]; 6];
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                ui.push_id("Caps", |ui| {
+                    ui.heading("Caps UV options");
+                    bevy_inspector::ui_for_value(&mut params.caps_uvs, ui, world);
+                    ui.heading("Caps Inset options");
+                    ui.scope(|ui| match &mut params.caps_inset {
+                        Some(opts) => {
+                            bevy_inspector::ui_for_value(opts, ui, world);
+                            if ui.button("Disable").clicked() {
+                                params.caps_inset = None;
+                            }
+                        }
+                        None => {
+                            if ui.button("Enable").clicked() {
+                                params.caps_inset = Some(InsetOptions {
+                                    keep_inner_face: true,
+                                    mode: InsetMode::Scale(0.2),
+                                })
+                            }
+                        }
+                    });
+                });
+                ui.separator();
+                ui.heading("Sides UV options");
+                ui.horizontal(|ui| {
+                    egui::ComboBox::from_id_source("Side Uv mode")
+                        .selected_text(params.sides_uvs_mode.label())
+                        .show_ui(ui, |ui| {
+                            let option = SideUVMode::Global;
+                            ui.selectable_value(&mut params.sides_uvs_mode, option, option.label());
+                            let option = SideUVMode::Multi;
+                            ui.selectable_value(&mut params.sides_uvs_mode, option, option.label());
+                        })
+                });
+                match params.sides_uvs_mode {
+                    SideUVMode::Global => {
+                        if bevy_inspector::ui_for_value(&mut params.sides_uvs[0], ui, world) {
+                            params.sides_uvs = [params.sides_uvs[0]; 6];
+                        }
                     }
-                    true
+                    SideUVMode::Multi => {
+                        bevy_inspector::ui_for_value(&mut params.sides_uvs, ui, world);
+                    }
                 }
-                SideUVMode::Multi => bevy_inspector::ui_for_value(&mut params.sides_uvs, ui, world),
+
+                ui.heading("Sides Inset options");
+                ui.push_id("Sides inset", |ui| match &mut params.sides_inset {
+                    Some(opts) => {
+                        bevy_inspector::ui_for_value(opts, ui, world);
+                        if ui.button("Disable").clicked() {
+                            params.sides_inset = None;
+                        }
+                    }
+                    None => {
+                        if ui.button("Enable").clicked() {
+                            params.sides_inset = Some(InsetOptions {
+                                keep_inner_face: true,
+                                mode: InsetMode::Scale(0.2),
+                            })
+                        }
+                    }
+                });
             });
         });
-        egui::Window::new("AmbientLight").show(egui_context.get_mut(), |ui| {
+    });
+    world.resource_scope(|world, mut materials: Mut<Assets<StandardMaterial>>| {
+        let Ok(egui_context) = world.query::<&mut EguiContext>().get_single(world) else {
+            return;
+        };
+        let mut egui_context = egui_context.clone();
+        egui::Window::new("Visuals").show(egui_context.get_mut(), |ui| {
             bevy_inspector::ui_for_resource::<AmbientLight>(world, ui);
+            let info = world.resource::<HexInfo>();
+            let mat = materials.get_mut(&info.material_handle).unwrap();
+            ui.collapsing("Material", |ui| {
+                bevy_inspector::ui_for_value(&mut mat.base_color, ui, world);
+                bevy_inspector::ui_for_value(&mut mat.double_sided, ui, world);
+                match &mut mat.cull_mode {
+                    Some(_) => {
+                        if ui.button("No Culling").clicked() {
+                            mat.cull_mode = None
+                        }
+                    }
+                    None => {
+                        if ui.button("Cull back faces").clicked() {
+                            mat.cull_mode = Some(bevy::render::render_resource::Face::Back);
+                        }
+                    }
+                }
+            });
         });
     });
 }
@@ -140,12 +207,17 @@ fn setup(
         .with_offset(Vec3::NEG_Y * params.height / 2.0)
         .build();
     let mesh_handle = meshes.add(compute_mesh(mesh));
-    let material = materials.add(texture);
+    let material_handle = materials.add(StandardMaterial {
+        base_color_texture: Some(texture),
+        cull_mode: None,
+        double_sided: true,
+        ..default()
+    });
     let mesh_entity = commands
         .spawn((
             PbrBundle {
                 mesh: mesh_handle.clone(),
-                material,
+                material: material_handle.clone(),
                 ..default()
             },
             Wireframe,
@@ -155,6 +227,7 @@ fn setup(
         layout,
         mesh_entity,
         mesh_handle,
+        material_handle,
     });
 }
 
@@ -224,6 +297,12 @@ fn update_mesh(params: Res<BuilderParams>, info: Res<HexInfo>, mut meshes: ResMu
     if !params.bottom_face {
         new_mesh = new_mesh.without_bottom_face();
     }
+    if let Some(opts) = params.caps_inset {
+        new_mesh = new_mesh.with_caps_inset_options(opts);
+    }
+    if let Some(opts) = params.sides_inset {
+        new_mesh = new_mesh.with_sides_inset_options(opts);
+    }
     let new_mesh = compute_mesh(new_mesh.build());
     // println!("Mesh has {} vertices", new_mesh.count_vertices());
     let mesh = meshes.get_mut(&info.mesh_handle).unwrap();
@@ -251,8 +330,10 @@ impl Default for BuilderParams {
             bottom_face: true,
             sides_uvs_mode: SideUVMode::Global,
             sides_uvs: [UVOptions::new().with_scale_factor(vec2(0.3, 1.0)); 6],
+            sides_inset: None,
             caps_uvs: UVOptions::new(),
             scale: Vec3::ONE,
+            caps_inset: None,
         }
     }
 }

--- a/src/mesh/column_builder.rs
+++ b/src/mesh/column_builder.rs
@@ -1,6 +1,6 @@
 use glam::{Quat, Vec3};
 
-use super::{MeshInfo, BASE_FACING};
+use super::{utils::Quad, MeshInfo, BASE_FACING};
 use crate::{Hex, HexLayout, PlaneMeshBuilder, UVOptions};
 
 /// Builder struct to customize hex column mesh generation.
@@ -221,7 +221,7 @@ impl<'l> ColumnMeshBuilder<'l> {
     /// Comsumes the builder to return the computed mesh data
     pub fn build(self) -> MeshInfo {
         // We compute the mesh at the origin to allow scaling
-        let mut cap_mesh = PlaneMeshBuilder::new(self.layout)
+        let cap_mesh = PlaneMeshBuilder::new(self.layout)
             .with_uv_options(self.caps_uv_options)
             .center_aligned()
             .build();
@@ -247,9 +247,9 @@ impl<'l> ColumnMeshBuilder<'l> {
                 let left = Vec3::new(left.x, height, left.y);
                 let right = Vec3::new(right.x, height, right.y);
                 let mut quad =
-                    MeshInfo::quad([left, right], Vec3::new(normal.x, 0.0, normal.y), delta);
+                    Quad::from_bottom([left, right], Vec3::new(normal.x, 0.0, normal.y), delta);
                 self.sides_uv_options[side].alter_uvs(&mut quad.uvs);
-                mesh.merge_with(quad);
+                mesh.merge_with(quad.into());
             }
         });
         if self.top_face {

--- a/src/mesh/column_builder.rs
+++ b/src/mesh/column_builder.rs
@@ -55,9 +55,9 @@ pub struct ColumnMeshBuilder<'l> {
     pub rotation: Option<Quat>,
     /// Amount of quads to be generated on the sides of the column
     pub subdivisions: Option<usize>,
-    /// Should the top hexagonal face be present
+    /// Top hexagonal face builder
     pub top_face: Option<PlaneMeshBuilder<'l>>,
-    /// Should the bottom hexagonal face be present
+    /// Bottom hexagonal face builder
     pub bottom_face: Option<PlaneMeshBuilder<'l>>,
     /// UV mapping options for the column sides
     pub sides_uv_options: [UVOptions; 6],

--- a/src/mesh/column_builder.rs
+++ b/src/mesh/column_builder.rs
@@ -1,7 +1,7 @@
 use glam::{Quat, Vec3};
 
 use super::{utils::Quad, MeshInfo, BASE_FACING};
-use crate::{Hex, HexLayout, InsetMode, InsetOptions, PlaneMeshBuilder, UVOptions};
+use crate::{Hex, HexLayout, InsetOptions, PlaneMeshBuilder, UVOptions};
 
 /// Builder struct to customize hex column mesh generation.
 ///
@@ -190,38 +190,6 @@ impl<'l> ColumnMeshBuilder<'l> {
         self
     }
 
-    #[must_use]
-    #[inline]
-    /// Specify scaled inset options for the top/bottom caps faces
-    ///
-    /// Note:
-    /// this won't have any effect if `top_cap` and `bottom_cap` are disabled
-    pub const fn with_scaled_inset_caps(mut self, scale: f32, keep_inner_face: bool) -> Self {
-        if let Some(builder) = self.top_face {
-            self.top_face = Some(builder.with_scaled_inset(scale, keep_inner_face));
-        }
-        if let Some(builder) = self.bottom_face {
-            self.bottom_face = Some(builder.with_scaled_inset(scale, keep_inner_face));
-        }
-        self
-    }
-
-    #[must_use]
-    #[inline]
-    /// Specify distance inset options for the top/bottom caps faces
-    ///
-    /// Note:
-    /// this won't have any effect if `top_cap` and `bottom_cap` are disabled
-    pub const fn with_distance_inset_caps(mut self, dist: f32, keep_inner_face: bool) -> Self {
-        if let Some(builder) = self.top_face {
-            self.top_face = Some(builder.with_distance_inset(dist, keep_inner_face));
-        }
-        if let Some(builder) = self.bottom_face {
-            self.bottom_face = Some(builder.with_distance_inset(dist, keep_inner_face));
-        }
-        self
-    }
-
     /// Specify inset option for the top/bottom caps faces
     ///
     /// Note:
@@ -278,28 +246,6 @@ impl<'l> ColumnMeshBuilder<'l> {
 
     #[must_use]
     #[inline]
-    /// Specify custom global scaled inset options for the side quads
-    pub const fn with_sides_scaled_inset(mut self, scale: f32, keep_inner_face: bool) -> Self {
-        self.sides_inset_options = Some(InsetOptions {
-            keep_inner_face,
-            mode: InsetMode::Scale(scale),
-        });
-        self
-    }
-
-    #[must_use]
-    #[inline]
-    /// Specify custom global scaled inset options for the side quads
-    pub const fn with_sides_distance_inset(mut self, dist: f32, keep_inner_face: bool) -> Self {
-        self.sides_inset_options = Some(InsetOptions {
-            keep_inner_face,
-            mode: InsetMode::Distance(dist),
-        });
-        self
-    }
-
-    #[must_use]
-    #[inline]
     /// Ignores the [`HexLayout::origin`] offset, generating a mesh centered
     /// around `(0.0, 0.0)`.
     pub const fn center_aligned(mut self) -> Self {
@@ -337,7 +283,7 @@ impl<'l> ColumnMeshBuilder<'l> {
                     Quad::from_bottom([left, right], Vec3::new(normal.x, 0.0, normal.y), delta);
                 self.sides_uv_options[side].alter_uvs(&mut quad.uvs);
                 let quad = if let Some(opts) = self.sides_inset_options {
-                    quad.inset(opts.mode, opts.keep_inner_face)
+                    quad.inset(opts.mode, opts.scale, opts.keep_inner_face)
                 } else {
                     quad.into()
                 };

--- a/src/mesh/column_builder.rs
+++ b/src/mesh/column_builder.rs
@@ -1,7 +1,7 @@
 use glam::{Quat, Vec3};
 
 use super::{utils::Quad, MeshInfo, BASE_FACING};
-use crate::{Hex, HexLayout, PlaneMeshBuilder, UVOptions};
+use crate::{Hex, HexLayout, InsetMode, InsetOptions, PlaneMeshBuilder, UVOptions};
 
 /// Builder struct to customize hex column mesh generation.
 ///
@@ -56,13 +56,13 @@ pub struct ColumnMeshBuilder<'l> {
     /// Amount of quads to be generated on the sides of the column
     pub subdivisions: Option<usize>,
     /// Should the top hexagonal face be present
-    pub top_face: bool,
+    pub top_face: Option<PlaneMeshBuilder<'l>>,
     /// Should the bottom hexagonal face be present
-    pub bottom_face: bool,
+    pub bottom_face: Option<PlaneMeshBuilder<'l>>,
     /// UV mapping options for the column sides
     pub sides_uv_options: [UVOptions; 6],
-    /// UV mapping options for top and bottom faces
-    pub caps_uv_options: UVOptions,
+    /// Quad inset options for the column sides
+    pub sides_inset_options: Option<InsetOptions>,
     /// If set to `true`, the mesh will ignore [`HexLayout::origin`]
     pub center_aligned: bool,
 }
@@ -79,11 +79,11 @@ impl<'l> ColumnMeshBuilder<'l> {
             subdivisions: None,
             offset: None,
             scale: None,
-            top_face: true,
-            bottom_face: true,
+            top_face: Some(PlaneMeshBuilder::new(layout)),
+            bottom_face: Some(PlaneMeshBuilder::new(layout)),
             sides_uv_options: [UVOptions::new(); 6],
-            caps_uv_options: UVOptions::new(),
             center_aligned: false,
+            sides_inset_options: None,
         }
     }
 
@@ -162,7 +162,7 @@ impl<'l> ColumnMeshBuilder<'l> {
     #[must_use]
     #[inline]
     pub const fn without_bottom_face(mut self) -> Self {
-        self.bottom_face = false;
+        self.bottom_face = None;
         self
     }
 
@@ -170,7 +170,7 @@ impl<'l> ColumnMeshBuilder<'l> {
     #[must_use]
     #[inline]
     pub const fn without_top_face(mut self) -> Self {
-        self.top_face = false;
+        self.top_face = None;
         self
     }
 
@@ -181,7 +181,60 @@ impl<'l> ColumnMeshBuilder<'l> {
     /// Note:
     /// this won't have any effect if `top_cap` and `bottom_cap` are disabled
     pub const fn with_caps_uv_options(mut self, uv_options: UVOptions) -> Self {
-        self.caps_uv_options = uv_options;
+        if let Some(builder) = self.top_face {
+            self.top_face = Some(builder.with_uv_options(uv_options));
+        }
+        if let Some(builder) = self.bottom_face {
+            self.bottom_face = Some(builder.with_uv_options(uv_options));
+        }
+        self
+    }
+
+    #[must_use]
+    #[inline]
+    /// Specify scaled inset options for the top/bottom caps faces
+    ///
+    /// Note:
+    /// this won't have any effect if `top_cap` and `bottom_cap` are disabled
+    pub const fn with_scaled_inset_caps(mut self, scale: f32, keep_inner_face: bool) -> Self {
+        if let Some(builder) = self.top_face {
+            self.top_face = Some(builder.with_scaled_inset(scale, keep_inner_face));
+        }
+        if let Some(builder) = self.bottom_face {
+            self.bottom_face = Some(builder.with_scaled_inset(scale, keep_inner_face));
+        }
+        self
+    }
+
+    #[must_use]
+    #[inline]
+    /// Specify distance inset options for the top/bottom caps faces
+    ///
+    /// Note:
+    /// this won't have any effect if `top_cap` and `bottom_cap` are disabled
+    pub const fn with_distance_inset_caps(mut self, dist: f32, keep_inner_face: bool) -> Self {
+        if let Some(builder) = self.top_face {
+            self.top_face = Some(builder.with_distance_inset(dist, keep_inner_face));
+        }
+        if let Some(builder) = self.bottom_face {
+            self.bottom_face = Some(builder.with_distance_inset(dist, keep_inner_face));
+        }
+        self
+    }
+
+    /// Specify inset option for the top/bottom caps faces
+    ///
+    /// Note:
+    /// this won't have any effect if `top_cap` and `bottom_cap` are disabled
+    #[must_use]
+    #[inline]
+    pub const fn with_caps_inset_options(mut self, opts: InsetOptions) -> Self {
+        if let Some(builder) = self.top_face {
+            self.top_face = Some(builder.with_inset_options(opts));
+        }
+        if let Some(builder) = self.bottom_face {
+            self.bottom_face = Some(builder.with_inset_options(opts));
+        }
         self
     }
 
@@ -201,8 +254,47 @@ impl<'l> ColumnMeshBuilder<'l> {
     /// Specify custom uv options for each of the side quad triangles.
     ///
     /// For a global setting prefer [`Self::with_sides_uv_options`]
+    pub fn with_sides_uv_options_fn(mut self, uv_options: impl Fn(usize) -> UVOptions) -> Self {
+        self.sides_uv_options = std::array::from_fn(uv_options);
+        self
+    }
+    #[must_use]
+    #[inline]
+    /// Specify custom uv options for each of the side quad triangles.
+    ///
+    /// For a global setting prefer [`Self::with_sides_uv_options`]
     pub const fn with_multi_sides_uv_options(mut self, uv_options: [UVOptions; 6]) -> Self {
         self.sides_uv_options = uv_options;
+        self
+    }
+
+    #[must_use]
+    #[inline]
+    /// Specify custom global inset options for the side quads
+    pub const fn with_sides_inset_options(mut self, options: InsetOptions) -> Self {
+        self.sides_inset_options = Some(options);
+        self
+    }
+
+    #[must_use]
+    #[inline]
+    /// Specify custom global scaled inset options for the side quads
+    pub const fn with_sides_scaled_inset(mut self, scale: f32, keep_inner_face: bool) -> Self {
+        self.sides_inset_options = Some(InsetOptions {
+            keep_inner_face,
+            mode: InsetMode::Scale(scale),
+        });
+        self
+    }
+
+    #[must_use]
+    #[inline]
+    /// Specify custom global scaled inset options for the side quads
+    pub const fn with_sides_distance_inset(mut self, dist: f32, keep_inner_face: bool) -> Self {
+        self.sides_inset_options = Some(InsetOptions {
+            keep_inner_face,
+            mode: InsetMode::Distance(dist),
+        });
         self
     }
 
@@ -220,11 +312,6 @@ impl<'l> ColumnMeshBuilder<'l> {
     #[allow(clippy::many_single_char_names)]
     /// Comsumes the builder to return the computed mesh data
     pub fn build(self) -> MeshInfo {
-        // We compute the mesh at the origin to allow scaling
-        let cap_mesh = PlaneMeshBuilder::new(self.layout)
-            .with_uv_options(self.caps_uv_options)
-            .center_aligned()
-            .build();
         // We store the offset to match the `self.pos`
         let pos = if self.center_aligned {
             self.layout.hex_to_center_aligned_world_pos(self.pos)
@@ -249,15 +336,27 @@ impl<'l> ColumnMeshBuilder<'l> {
                 let mut quad =
                     Quad::from_bottom([left, right], Vec3::new(normal.x, 0.0, normal.y), delta);
                 self.sides_uv_options[side].alter_uvs(&mut quad.uvs);
-                mesh.merge_with(quad.into());
+                let quad = if let Some(opts) = self.sides_inset_options {
+                    quad.inset(opts.mode, opts.keep_inner_face)
+                } else {
+                    quad.into()
+                };
+                mesh.merge_with(quad);
             }
         });
-        if self.top_face {
-            mesh.merge_with(cap_mesh.clone().with_offset(Vec3::Y * self.height));
+        // Hexagon top face
+        if let Some(builder) = self.top_face {
+            mesh.merge_with(
+                builder
+                    .center_aligned()
+                    .with_offset(Vec3::Y * self.height)
+                    .build(),
+            );
         }
-        if self.bottom_face {
+        // Hexagon bottom face
+        if let Some(builder) = self.bottom_face {
             let rotation = Quat::from_rotation_arc(BASE_FACING, -BASE_FACING);
-            let bottom_face = cap_mesh.rotated(rotation);
+            let bottom_face = builder.center_aligned().build().rotated(rotation);
             mesh.merge_with(bottom_face);
         }
         // **S** - We apply optional scale

--- a/src/mesh/column_builder.rs
+++ b/src/mesh/column_builder.rs
@@ -221,7 +221,7 @@ impl<'l> ColumnMeshBuilder<'l> {
     /// Comsumes the builder to return the computed mesh data
     pub fn build(self) -> MeshInfo {
         // We compute the mesh at the origin to allow scaling
-        let cap_mesh = PlaneMeshBuilder::new(self.layout)
+        let mut cap_mesh = PlaneMeshBuilder::new(self.layout)
             .with_uv_options(self.caps_uv_options)
             .center_aligned()
             .build();
@@ -237,7 +237,7 @@ impl<'l> ColumnMeshBuilder<'l> {
         // Column sides
         let subidivisions = self.subdivisions.unwrap_or(0).max(1);
         let delta = self.height / subidivisions as f32;
-        let [a, b, c, d, e, f] = self.layout.hex_corners(Hex::ZERO);
+        let [a, b, c, d, e, f] = self.layout.center_aligned_hex_corners();
         let corners = [[a, b], [b, c], [c, d], [d, e], [e, f], [f, a]];
         (0..6).for_each(|side| {
             let [left, right] = corners[side];
@@ -262,7 +262,7 @@ impl<'l> ColumnMeshBuilder<'l> {
         }
         // **S** - We apply optional scale
         if let Some(scale) = self.scale {
-            mesh.vertices.iter_mut().for_each(|p| *p *= scale);
+            mesh = mesh.with_scale(scale);
         }
         // **R** - We rotate the mesh to face the given direction
         if let Some(rotation) = self.rotation {

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -24,8 +24,28 @@ pub(crate) const BASE_FACING: Vec3 = Vec3::Y;
 pub struct InsetOptions {
     /// If set to `true``the original downscaled face will be kept
     pub keep_inner_face: bool,
-    /// Inset face scale relative to the original scale
-    pub scale: f32,
+    /// Inset mode
+    pub mode: InsetMode,
+}
+
+/// [`InsetOptions`] mode, defining the inset behaviour
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub enum InsetMode {
+    /// Each inset vertex position will be at a scale of the original one
+    Scale(f32),
+    /// Each inset vertex position will be at a fixed distance of the original one
+    Distance(f32),
+}
+
+impl InsetMode {
+    pub(crate) fn should_flip(self) -> bool {
+        match self {
+            Self::Scale(s) => s < 0.0,
+            Self::Distance(d) => d < 0.0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -24,28 +24,24 @@ pub(crate) const BASE_FACING: Vec3 = Vec3::Y;
 pub struct InsetOptions {
     /// If set to `true``the original downscaled face will be kept
     pub keep_inner_face: bool,
+    /// Scale factor
+    pub scale: f32,
     /// Inset mode
-    pub mode: InsetMode,
+    pub mode: InsetScaleMode,
 }
 
-/// [`InsetOptions`] mode, defining the inset behaviour
-#[derive(Debug, Copy, Clone)]
+/// [`InsetOptions`] mode, defining the inset scaling behaviour
+#[derive(Debug, Copy, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
-pub enum InsetMode {
+pub enum InsetScaleMode {
+    #[default]
     /// Each inset vertex position will be at a scale of the original one
-    Scale(f32),
-    /// Each inset vertex position will be at a fixed distance of the original one
-    Distance(f32),
-}
-
-impl InsetMode {
-    pub(crate) fn should_flip(self) -> bool {
-        match self {
-            Self::Scale(s) => s < 0.0,
-            Self::Distance(d) => d < 0.0,
-        }
-    }
+    /// relative to the centroid of the face
+    Centroid,
+    /// Each inset vertex position will be at a proportional scale of the original one
+    /// relative to its smallest edge
+    SmallestEdge,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -39,8 +39,8 @@ pub enum InsetScaleMode {
     /// Each inset vertex position will be at a scale of the original one
     /// relative to the centroid of the face
     Centroid,
-    /// Each inset vertex position will be at a proportional scale of the original one
-    /// relative to its smallest edge
+    /// Each inset vertex position will be at a proportional scale of the
+    /// original one relative to its smallest edge
     SmallestEdge,
 }
 

--- a/src/mesh/plane_builder.rs
+++ b/src/mesh/plane_builder.rs
@@ -1,6 +1,4 @@
-use crate::{
-    utils::Hexagon, Hex, HexLayout, InsetMode, InsetOptions, MeshInfo, UVOptions, BASE_FACING,
-};
+use crate::{utils::Hexagon, Hex, HexLayout, InsetOptions, MeshInfo, UVOptions, BASE_FACING};
 use glam::{Quat, Vec3};
 
 /// Builder struct to customize hex plane mesh generation.
@@ -118,40 +116,6 @@ impl<'l> PlaneMeshBuilder<'l> {
         self
     }
 
-    /// Specify scale insetting option for the hexagonal face
-    ///
-    /// # Arguments
-    ///
-    /// * `scale` - the scale of the new insetted vertices,
-    /// * `keep_inner_face` - If set to true the insetted face will be kept, otherwise
-    /// it will be removed
-    #[must_use]
-    #[inline]
-    pub const fn with_scaled_inset(mut self, scale: f32, keep_inner_face: bool) -> Self {
-        self.inset_options = Some(InsetOptions {
-            keep_inner_face,
-            mode: InsetMode::Scale(scale),
-        });
-        self
-    }
-
-    /// Specify distance insetting option for the hexagonal face
-    ///
-    /// # Arguments
-    ///
-    /// * `dist` - the distance of the new insetted vertices relative to their original ones
-    /// * `keep_inner_face` - If set to true the insetted face will be kept, otherwise
-    /// it will be removed
-    #[must_use]
-    #[inline]
-    pub const fn with_distance_inset(mut self, dist: f32, keep_inner_face: bool) -> Self {
-        self.inset_options = Some(InsetOptions {
-            keep_inner_face,
-            mode: InsetMode::Distance(dist),
-        });
-        self
-    }
-
     /// Specify insetting option for the hexagonal face
     #[must_use]
     #[inline]
@@ -174,7 +138,7 @@ impl<'l> PlaneMeshBuilder<'l> {
         let mut offset = Vec3::new(pos.x, 0.0, pos.y);
         // We apply optional insetting
         let mut mesh = if let Some(inset) = self.inset_options {
-            face.inset(inset.mode, inset.keep_inner_face)
+            face.inset(inset.mode, inset.scale, inset.keep_inner_face)
         } else {
             face.into()
         };

--- a/src/mesh/plane_builder.rs
+++ b/src/mesh/plane_builder.rs
@@ -128,7 +128,7 @@ impl<'l> PlaneMeshBuilder<'l> {
         let mut offset = Vec3::new(pos.x, 0.0, pos.y);
         // **S** - We apply optional scale
         if let Some(scale) = self.scale {
-            mesh.vertices.iter_mut().for_each(|p| *p *= scale);
+            mesh = mesh.with_scale(scale);
         }
         // **R** - We rotate the mesh to face the given direction
         if let Some(rotation) = self.rotation {

--- a/src/mesh/plane_builder.rs
+++ b/src/mesh/plane_builder.rs
@@ -1,5 +1,5 @@
-use super::{MeshInfo, BASE_FACING};
-use crate::{Hex, HexLayout, UVOptions};
+use super::{utils::Hexagon, MeshInfo, BASE_FACING};
+use crate::{Hex, HexLayout, InsetOptions, UVOptions};
 use glam::{Quat, Vec3};
 
 /// Builder struct to customize hex plane mesh generation.
@@ -36,6 +36,8 @@ pub struct PlaneMeshBuilder<'l> {
     pub uv_options: UVOptions,
     /// If set to `true`, the mesh will ignore [`HexLayout::origin`]
     pub center_aligned: bool,
+    /// Optional inset options for the plane face
+    pub inset_options: Option<InsetOptions>,
 }
 
 impl<'l> PlaneMeshBuilder<'l> {
@@ -50,6 +52,7 @@ impl<'l> PlaneMeshBuilder<'l> {
             scale: None,
             uv_options: UVOptions::new(),
             center_aligned: false,
+            inset_options: None,
         }
     }
 
@@ -114,11 +117,28 @@ impl<'l> PlaneMeshBuilder<'l> {
         self
     }
 
+    /// Specify insetting option for the hexagonal face
+    ///
+    /// # Arguments
+    ///
+    /// * `scale` the scale of the new insetted vertices,
+    /// * `keep_inner_face` - If set to true the insetted face will be kept, otherwise
+    /// it will be removed
+    #[must_use]
+    #[inline]
+    pub const fn with_inset_face(mut self, scale: f32, keep_inner_face: bool) -> Self {
+        self.inset_options = Some(InsetOptions {
+            keep_inner_face,
+            scale,
+        });
+        self
+    }
+
     /// Comsumes the builder to return the computed mesh data
     #[must_use]
     pub fn build(self) -> MeshInfo {
         // We compute the mesh at the origin and no offset to allow scaling
-        let mut mesh = MeshInfo::center_aligned_hexagonal_plane(self.layout);
+        let face = Hexagon::center_aligned(self.layout);
         // We store the offset to match the `self.pos`
         let pos = if self.center_aligned {
             self.layout.hex_to_center_aligned_world_pos(self.pos)
@@ -126,6 +146,12 @@ impl<'l> PlaneMeshBuilder<'l> {
             self.layout.hex_to_world_pos(self.pos)
         };
         let mut offset = Vec3::new(pos.x, 0.0, pos.y);
+        // We apply optional insetting
+        let mut mesh = if let Some(inset) = self.inset_options {
+            face.inset(inset.scale, inset.keep_inner_face)
+        } else {
+            face.into()
+        };
         // **S** - We apply optional scale
         if let Some(scale) = self.scale {
             mesh = mesh.with_scale(scale);

--- a/src/mesh/plane_builder.rs
+++ b/src/mesh/plane_builder.rs
@@ -1,5 +1,6 @@
-use super::{utils::Hexagon, MeshInfo, BASE_FACING};
-use crate::{Hex, HexLayout, InsetOptions, UVOptions};
+use crate::{
+    utils::Hexagon, Hex, HexLayout, InsetMode, InsetOptions, MeshInfo, UVOptions, BASE_FACING,
+};
 use glam::{Quat, Vec3};
 
 /// Builder struct to customize hex plane mesh generation.
@@ -117,20 +118,45 @@ impl<'l> PlaneMeshBuilder<'l> {
         self
     }
 
-    /// Specify insetting option for the hexagonal face
+    /// Specify scale insetting option for the hexagonal face
     ///
     /// # Arguments
     ///
-    /// * `scale` the scale of the new insetted vertices,
+    /// * `scale` - the scale of the new insetted vertices,
     /// * `keep_inner_face` - If set to true the insetted face will be kept, otherwise
     /// it will be removed
     #[must_use]
     #[inline]
-    pub const fn with_inset_face(mut self, scale: f32, keep_inner_face: bool) -> Self {
+    pub const fn with_scaled_inset(mut self, scale: f32, keep_inner_face: bool) -> Self {
         self.inset_options = Some(InsetOptions {
             keep_inner_face,
-            scale,
+            mode: InsetMode::Scale(scale),
         });
+        self
+    }
+
+    /// Specify distance insetting option for the hexagonal face
+    ///
+    /// # Arguments
+    ///
+    /// * `dist` - the distance of the new insetted vertices relative to their original ones
+    /// * `keep_inner_face` - If set to true the insetted face will be kept, otherwise
+    /// it will be removed
+    #[must_use]
+    #[inline]
+    pub const fn with_distance_inset(mut self, dist: f32, keep_inner_face: bool) -> Self {
+        self.inset_options = Some(InsetOptions {
+            keep_inner_face,
+            mode: InsetMode::Distance(dist),
+        });
+        self
+    }
+
+    /// Specify insetting option for the hexagonal face
+    #[must_use]
+    #[inline]
+    pub const fn with_inset_options(mut self, opts: InsetOptions) -> Self {
+        self.inset_options = Some(opts);
         self
     }
 
@@ -148,7 +174,7 @@ impl<'l> PlaneMeshBuilder<'l> {
         let mut offset = Vec3::new(pos.x, 0.0, pos.y);
         // We apply optional insetting
         let mut mesh = if let Some(inset) = self.inset_options {
-            face.inset(inset.scale, inset.keep_inner_face)
+            face.inset(inset.mode, inset.keep_inner_face)
         } else {
             face.into()
         };

--- a/src/mesh/utils.rs
+++ b/src/mesh/utils.rs
@@ -7,7 +7,7 @@ type VertexIdx = u16;
 #[derive(Debug, Clone, Copy)]
 pub struct Tri(pub [VertexIdx; 3]);
 
-/// Represnetation of a primitive face, with a fixed amount of vertices and triangles
+/// Representation of a primitive face, with a fixed amount of vertices and triangles
 #[derive(Debug, Clone)]
 pub struct Face<const VERTS: usize, const TRIS: usize> {
     /// Vertex positions

--- a/src/mesh/utils.rs
+++ b/src/mesh/utils.rs
@@ -1,0 +1,167 @@
+use crate::{HexLayout, MeshInfo, UVOptions, BASE_FACING};
+use glam::{Vec2, Vec3};
+
+type VertexIdx = u16;
+
+/// Structure storing three vertex indices
+#[derive(Debug, Clone, Copy)]
+pub struct Tri(pub [VertexIdx; 3]);
+
+/// Represnetation of a primitive face, with a fixed amount of vertices and triangles
+#[derive(Debug, Clone)]
+pub struct Face<const VERTS: usize, const TRIS: usize> {
+    /// Vertex positions
+    pub positions: [Vec3; VERTS],
+    /// Vertex normals
+    pub normals: [Vec3; VERTS],
+    /// Vertex uvs
+    pub uvs: [Vec2; VERTS],
+    /// Triangle indices
+    pub triangles: [Tri; TRIS],
+}
+
+/// A Quad face made of 4 vertices and 2 triangles
+pub type Quad = Face<4, 2>;
+/// An hexagonal face made of 6 vertices and 4 triangles
+pub type Hexagon = Face<6, 4>;
+
+impl Tri {
+    /// Flips the vertex indices order, effectively making the triangle face
+    /// the other way
+    pub fn flip(&mut self) {
+        let [a, b, c] = self.0;
+        self.0 = [c, b, a];
+    }
+}
+
+impl Quad {
+    /// Construct a regular quad from two [`left`, `right`] bottom positions
+    /// and a `height`
+    ///
+    /// # Arguments
+    /// * `[left, right]` - the two bottom vertex positions
+    /// * `normal` - the normal to be applied to all 4 vertices
+    /// * `height` - the top vertices distance to the bottom ones alogn the Y axis
+    #[must_use]
+    pub fn from_bottom([left, right]: [Vec3; 2], normal: Vec3, height: f32) -> Self {
+        let offset = BASE_FACING * height;
+        Self {
+            positions: [right, right + offset, left + offset, left],
+            normals: [normal; 4],
+            uvs: [Vec2::X, Vec2::ONE, Vec2::Y, Vec2::ZERO],
+            // 2 - 1
+            // | \ |
+            // 3 - 0
+            triangles: [
+                Tri([2, 1, 0]), // Tri 1
+                Tri([0, 3, 2]), // Tri 2
+            ],
+        }
+    }
+}
+
+impl Hexagon {
+    /// Constructs a _center aligned_ (no offset) hexagon face from the given `layout`
+    #[must_use]
+    pub fn center_aligned(layout: &HexLayout) -> Self {
+        let corners = layout.center_aligned_hex_corners();
+        let uvs = corners.map(UVOptions::wrap_uv);
+        let positions = corners.map(|p| Vec3::new(p.x, 0., p.y));
+        Self {
+            positions,
+            uvs,
+            normals: [BASE_FACING; 6],
+            triangles: [
+                Tri([0, 2, 1]), // Top tri
+                Tri([3, 5, 4]), // Bot tri
+                Tri([0, 5, 3]), // Mid Quad
+                Tri([3, 2, 0]), // Mid Quad
+            ],
+        }
+    }
+}
+
+impl<const VERTS: usize, const TRIS: usize> Face<VERTS, TRIS> {
+    /// Computes the centroid of the face positions
+    #[inline]
+    #[must_use]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn centroid(&self) -> Vec3 {
+        self.positions.iter().sum::<Vec3>() / VERTS as f32
+    }
+
+    /// Computes the centroid of the face uvs
+    #[inline]
+    #[must_use]
+    #[allow(clippy::cast_precision_loss)]
+    pub fn uv_centroid(&self) -> Vec2 {
+        self.uvs.iter().sum::<Vec2>() / VERTS as f32
+    }
+
+    /// Performs an _inset_ operition on the mesh, assuming the mesh is a _looping face_,
+    /// either a quad, triangle or hexagonal face.
+    ///
+    /// # Arguments
+    ///
+    /// * `scale` the scale of the new insetted vertices
+    /// * `keep_inner_face` - If set to true the insetted face will be kept, otherwise
+    /// it will be removed
+    #[allow(clippy::cast_possible_truncation)]
+    #[must_use]
+    pub fn inset(self, scale: f32, keep_inner_face: bool) -> MeshInfo {
+        // We compute the inset mesh, identical to the original face
+        let mut inset_face = self.clone();
+        // We downscale the inset face vertices and uvs along its plane
+        {
+            // vertices
+            let centroid = inset_face.centroid();
+            inset_face.positions.iter_mut().for_each(|v| {
+                let dir = (*v - centroid) * scale;
+                *v = centroid + dir;
+            });
+            // uvs
+            let uv_centroid = inset_face.uv_centroid();
+            inset_face.uvs.iter_mut().for_each(|uv| {
+                let dir = (*uv - uv_centroid) * scale;
+                *uv = uv_centroid + dir;
+            });
+        }
+        let mut inset_face = MeshInfo::from(inset_face);
+        if !keep_inner_face {
+            inset_face.indices.clear();
+        }
+        let mut mesh = MeshInfo::from(self);
+        mesh.indices.clear();
+        let vertex_count = VERTS as u16;
+        let connection_indices = (0..vertex_count).flat_map(|v_idx| {
+            let next_v_idx = (v_idx + 1) % vertex_count;
+            let inset_v_idx = v_idx + vertex_count;
+            let next_inset_v_idx = next_v_idx + vertex_count;
+
+            let [mut a, mut b] = [
+                Tri([next_inset_v_idx, next_v_idx, v_idx]),
+                Tri([v_idx, inset_v_idx, next_inset_v_idx]),
+            ];
+            if scale > 1.0 {
+                a.flip();
+                b.flip();
+            }
+            a.0.into_iter().chain(b.0)
+        });
+        mesh.indices.extend(connection_indices);
+        mesh.merge_with(inset_face);
+        mesh
+    }
+}
+
+impl<const VERTS: usize, const TRIS: usize> From<Face<VERTS, TRIS>> for MeshInfo {
+    #[allow(clippy::many_single_char_names)]
+    fn from(face: Face<VERTS, TRIS>) -> Self {
+        Self {
+            vertices: face.positions.to_vec(),
+            normals: face.normals.to_vec(),
+            uvs: face.uvs.to_vec(),
+            indices: face.triangles.into_iter().flat_map(|t| t.0).collect(),
+        }
+    }
+}

--- a/src/mesh/utils.rs
+++ b/src/mesh/utils.rs
@@ -7,7 +7,8 @@ type VertexIdx = u16;
 #[derive(Debug, Clone, Copy)]
 pub struct Tri(pub [VertexIdx; 3]);
 
-/// Representation of a primitive face, with a fixed amount of vertices and triangles
+/// Representation of a primitive face, with a fixed amount of vertices and
+/// triangles
 #[derive(Debug, Clone)]
 pub struct Face<const VERTS: usize, const TRIS: usize> {
     /// Vertex positions
@@ -41,7 +42,8 @@ impl Quad {
     /// # Arguments
     /// * `[left, right]` - the two bottom vertex positions
     /// * `normal` - the normal to be applied to all 4 vertices
-    /// * `height` - the top vertices distance to the bottom ones alogn the Y axis
+    /// * `height` - the top vertices distance to the bottom ones alogn the Y
+    ///   axis
     #[must_use]
     pub fn from_bottom([left, right]: [Vec3; 2], normal: Vec3, height: f32) -> Self {
         let offset = BASE_FACING * height;
@@ -61,7 +63,8 @@ impl Quad {
 }
 
 impl Hexagon {
-    /// Constructs a _center aligned_ (no offset) hexagon face from the given `layout`
+    /// Constructs a _center aligned_ (no offset) hexagon face from the given
+    /// `layout`
     #[must_use]
     pub fn center_aligned(layout: &HexLayout) -> Self {
         let corners = layout.center_aligned_hex_corners();
@@ -98,13 +101,14 @@ impl<const VERTS: usize, const TRIS: usize> Face<VERTS, TRIS> {
         self.uvs.iter().sum::<Vec2>() / VERTS as f32
     }
 
-    /// Performs an _inset_ operition on the mesh, assuming the mesh is a _looping face_,
-    /// either a quad, triangle or hexagonal face.
+    /// Performs an _inset_ operition on the mesh, assuming the mesh is a
+    /// _looping face_, either a quad, triangle or hexagonal face.
     ///
     /// # Arguments
     ///
     /// * `mode` - the insetting behaviour mode
-    /// * `keep_inner_face` - If set to true the insetted face will be kept, otherwise
+    /// * `keep_inner_face` - If set to true the insetted face will be kept,
+    ///   otherwise
     /// it will be removed
     #[allow(clippy::cast_possible_truncation)]
     #[must_use]

--- a/src/mesh/uv_mapping.rs
+++ b/src/mesh/uv_mapping.rs
@@ -141,20 +141,6 @@ impl UVOptions {
         }
     }
 
-    /// Default values for hexagonal planes or column caps
-    #[must_use]
-    #[deprecated(since = "0.14.0", note = "Use `UVOptions::new` instead")]
-    pub const fn cap_default() -> Self {
-        Self::new()
-    }
-
-    /// Default values for quads
-    #[must_use]
-    #[deprecated(since = "0.14.0", note = "Use `UVOptions::new` instead")]
-    pub const fn quad_default() -> Self {
-        Self::new()
-    }
-
     /// This function maps `p` to be normalized and between 0 and 1
     #[inline]
     pub(crate) fn wrap_uv(p: Vec2) -> Vec2 {

--- a/src/mesh/uv_mapping.rs
+++ b/src/mesh/uv_mapping.rs
@@ -135,7 +135,7 @@ impl UVOptions {
     }
 
     /// Apply the options to all UV coords in `uvs`
-    pub fn alter_uvs(&self, uvs: &mut Vec<Vec2>) {
+    pub fn alter_uvs(&self, uvs: &mut [Vec2]) {
         for uv in uvs {
             *uv = self.alter_uv(*uv);
         }


### PR DESCRIPTION
> Supercedes #151 
> Fixes https://github.com/ManevilleF/hexx/discussions/150

# Work done

- [x] Overhaul of primitive shape generation (Quads and hexagons), added a mesh `utils` module with the primitive faces
- [x] Added face inset options to both builders
- [x] Overhaul of how Column mesh builder handles the caps options  

<img width="1077" alt="Screenshot 2024-02-28 at 11 29 14" src="https://github.com/ManevilleF/hexx/assets/26703856/7656c497-438c-4e61-9398-ff2198997bda">

> Insetting hexagons and quads in mesh example

<img width="720" alt="Screenshot 2024-02-28 at 11 49 16" src="https://github.com/ManevilleF/hexx/assets/26703856/7002e4c6-ebb7-41f2-85bc-ab2e0eb9f4c5">

> Example of insetting used in hex grid example