### PR TITLE
Grid edges and vertices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 * Added `z` field in the `Debug` impl of `Hex` (#156)
 * Added `xyz` fields in the `Debug` impl of directions (#156)
 
+### New grid utilities (#154)
+
+* Added new `grid` feature gate
+* Added `GridVertex` and `GridEgde` types, representing oriented grid vertices
+and edges
+
 ### New directions (#156)
 
 * (**BREAKING**) Renamed `Direction` to `EdgeDirection`, and is no longer an enum.
@@ -24,6 +30,8 @@ longer an enum. Instead of the oriented variants use associated const values:
   * `DiagonalDirection::Left` -> `VertexDirection::FLAT_LEFT` or `VertexDirection::POINTY_TOP_LEFT`
   * `DiagonalDirection::BottomLeft` -> `VertexDirection::FLAT_BOTTOM_LEFT` or `VertexDirection::POINTY_BOTTOM_LEFT`
   * `DiagonalDirection::BottomRight` -> `VertexDirection::FLAT_BOTTOM_RIGHT` or `VertexDirection::POINTY_BOTTOM`
+* Fixed angle inconsistencies in both direction types
+* (**BREAKING**) Removed `HexOrientation::direction_angle` method
 
 ### Mesh generation overhaul (#152)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ exclude = [".github"]
 resolver = "2"
 
 [features]
-default = ["algorithms", "mesh"]
+default = ["algorithms", "mesh", "grid"]
 # HL algoritms
 algorithms = []
 # 3d Mesh features
 mesh = ["serde?/std"]
+# Grid management utilities
+grid = []
 # repr C
 packed = []
 # serde compatibility

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@
 
  * `hexx = { version = "0.15", features = ["bevy_reflect"] }`
 
+ `hexx` supports Face/Vertex/Edge [grid handling](https://www.redblobgames.com/grids/parts/#hexagon-coordinates)
+ using `Hex` as Face, `GridVertex` as vertex and `GridEdge` as edge. To enable it add the
+ following line to your `Cargo.toml`:
+
+ * `hexx = { version = "0.15", features = ["grid"] }`
+
  ## Features
 
  `hexx` provides the [`Hex`] coordinates with:

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@
  * `hexx = { version = "0.15", features = ["bevy_reflect"] }`
 
  `hexx` supports Face/Vertex/Edge [grid handling](https://www.redblobgames.com/grids/parts/#hexagon-coordinates)
- using `Hex` as Face, `GridVertex` as vertex and `GridEdge` as edge. To enable it add the
- following line to your `Cargo.toml`:
+ using `Hex` as Face, `GridVertex` as vertex and `GridEdge` as edge. To
+ enable it add the following line to your `Cargo.toml`:
 
  * `hexx = { version = "0.15", features = ["grid"] }`
 

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -12,6 +12,7 @@ const HEX_SIZE: Vec2 = Vec2::splat(13.0);
 
 pub fn main() {
     App::new()
+        .init_resource::<HighlightedHexes>()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 resolution: (1_000.0, 1_000.0).into(),
@@ -20,7 +21,7 @@ pub fn main() {
             ..default()
         }))
         .add_systems(Startup, (setup_camera, setup_grid))
-        .add_systems(Update, handle_input)
+        .add_systems(Update, (handle_input, gizmos).chain())
         .run();
 }
 
@@ -123,7 +124,7 @@ fn handle_input(
     windows: Query<&Window, With<PrimaryWindow>>,
     cameras: Query<(&Camera, &GlobalTransform)>,
     map: Res<Map>,
-    mut highlighted_hexes: Local<HighlightedHexes>,
+    mut highlighted_hexes: ResMut<HighlightedHexes>,
 ) {
     let window = windows.single();
     let (camera, cam_transform) = cameras.single();
@@ -197,11 +198,18 @@ fn handle_input(
     }
 }
 
+fn gizmos(mut gizmos: Gizmos, higlights: Res<HighlightedHexes>, map: Res<Map>) {
+    let selected = higlights.selected;
+    for [a, b] in selected.all_edges().map(|e| map.layout.edge_coordinates(e)) {
+        gizmos.line_2d(a, b, Color::CYAN);
+    }
+}
+
 /// Compute a bevy mesh from the layout
 fn hexagonal_plane(hex_layout: &HexLayout) -> Mesh {
     let mesh_info = PlaneMeshBuilder::new(hex_layout)
         .facing(Vec3::Z)
-        .with_scale(Vec3::splat(0.95))
+        .with_scale(Vec3::splat(0.98))
         .center_aligned()
         .build();
     Mesh::new(

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -201,7 +201,7 @@ fn handle_input(
 fn gizmos(mut gizmos: Gizmos, higlights: Res<HighlightedHexes>, map: Res<Map>) {
     let selected = higlights.selected;
     for [a, b] in selected.all_edges().map(|e| map.layout.edge_coordinates(e)) {
-        gizmos.line_2d(a, b, Color::CYAN);
+        gizmos.line_2d(a, b, Color::LIME_GREEN);
     }
 }
 

--- a/src/direction/edge_direction.rs
+++ b/src/direction/edge_direction.rs
@@ -46,6 +46,24 @@ use std::{f32::consts::TAU, fmt::Debug};
 /// assert_eq!(direction >> 1, EdgeDirection::FLAT_TOP_RIGHT);
 /// assert_eq!(direction << 1, EdgeDirection::FLAT_TOP_LEFT);
 /// ```
+///
+/// ## Storage
+///
+/// Both [`EdgeDirection`] and [`VertexDirection`] store a u8 byte between 0 and
+/// 5 as following:
+///
+/// ```txt
+///           e1
+///       v2_____ v1
+///     e2 /     \ e0
+///       /       \
+///   v3 (         ) v0
+///       \       /
+///     e3 \_____/ e5
+///      v4   e5  v5
+/// ```
+///
+/// On pointy orientation the hexagon is shifted by 30 degrees clockwise
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -191,7 +209,7 @@ impl EdgeDirection {
     /// Converts the direction to a normalized hex coordinate
     #[must_use]
     #[inline]
-    pub const fn into_inner(self) -> Hex {
+    pub const fn into_hex(self) -> Hex {
         Hex::NEIGHBORS_COORDS[self.0 as usize]
     }
 
@@ -560,14 +578,14 @@ impl EdgeDirection {
 
 impl From<EdgeDirection> for Hex {
     fn from(value: EdgeDirection) -> Self {
-        value.into_inner()
+        value.into_hex()
     }
 }
 
 #[cfg(not(target_arch = "spirv"))]
 impl Debug for EdgeDirection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let c = self.into_inner();
+        let c = self.into_hex();
         f.debug_struct("EdgeDirection")
             .field("index", &self.0)
             .field("x", &c.x)

--- a/src/direction/edge_direction.rs
+++ b/src/direction/edge_direction.rs
@@ -73,6 +73,8 @@ use std::{f32::consts::TAU, fmt::Debug};
 pub struct EdgeDirection(pub(crate) u8);
 
 impl EdgeDirection {
+    /// Direction towards `X, -Y`
+    pub const X_NEG_Y: Self = Self(0);
     /// Direction to (1, -1)
     ///
     /// Represents "Top right" edge in flat orientation
@@ -90,6 +92,8 @@ impl EdgeDirection {
     /// Represents "North west" edge in pointy orientation
     pub const POINTY_WEST: Self = Self(0);
 
+    /// Direction towards `-Y`
+    pub const NEG_Y: Self = Self(1);
     /// Direction to (0, -1)
     ///
     /// Represents "Top" edge in flat orientation
@@ -107,6 +111,8 @@ impl EdgeDirection {
     /// Represents "North West" edge in pointy orientation
     pub const POINTY_NORTH_WEST: Self = Self(1);
 
+    /// Direction towards `-X`
+    pub const NEG_X: Self = Self(2);
     /// Direction to (-1, 0)
     ///
     /// Represents "Top Left" in flat orientation
@@ -124,6 +130,8 @@ impl EdgeDirection {
     /// Represents "North East" in pointy orientation
     pub const POINTY_NORTH_EAST: Self = Self(2);
 
+    /// Direction towards `-X, Y`
+    pub const NEG_X_Y: Self = Self(3);
     /// Direction to (-1, 1)
     ///
     /// Represents "Bottom Left" in flat orientation
@@ -141,6 +149,8 @@ impl EdgeDirection {
     /// Represents "East" in pointy orientation
     pub const POINTY_EAST: Self = Self(3);
 
+    /// Direction towards `Y`
+    pub const Y: Self = Self(4);
     /// Direction to (0, 1)
     ///
     /// Represents "Bottom" in flat orientation
@@ -158,6 +168,8 @@ impl EdgeDirection {
     /// Represents "South east" in pointy orientation
     pub const POINTY_SOUTH_EAST: Self = Self(4);
 
+    /// Direction towards `X`
+    pub const X: Self = Self(5);
     /// Direction to (1, 0)
     ///
     /// Represents "Bottom Right" in flat orientation

--- a/src/direction/edge_direction.rs
+++ b/src/direction/edge_direction.rs
@@ -322,7 +322,7 @@ impl EdgeDirection {
     ///
     /// See [`Self::angle_flat`] for *flat* hexagons
     pub fn angle_pointy(self) -> f32 {
-        self.angle_between(Self::default())
+        self.angle_between(Self(0))
     }
 
     #[inline]

--- a/src/direction/edge_direction.rs
+++ b/src/direction/edge_direction.rs
@@ -291,8 +291,9 @@ impl EdgeDirection {
     #[allow(clippy::cast_lossless)]
     #[must_use]
     #[inline]
+    #[doc(alias = "angle_between")]
     /// Computes the angle between `self` and `rhs` in radians.
-    pub fn angle_between(self, rhs: Self) -> f32 {
+    pub fn angle_to(self, rhs: Self) -> f32 {
         let steps = self.steps_between(rhs) as f32;
         steps * DIRECTION_ANGLE_RAD
     }
@@ -300,8 +301,9 @@ impl EdgeDirection {
     #[allow(clippy::cast_lossless)]
     #[must_use]
     #[inline]
+    #[doc(alias = "angle_degrees_between")]
     /// Computes the angle between `self` and `rhs` in degrees.
-    pub fn angle_degrees_between(self, rhs: Self) -> f32 {
+    pub fn angle_degrees_to(self, rhs: Self) -> f32 {
         let steps = self.steps_between(rhs) as f32;
         steps * DIRECTION_ANGLE_DEGREES
     }
@@ -312,7 +314,7 @@ impl EdgeDirection {
     ///
     /// See [`Self::angle_pointy`] for *pointy* hexagons
     pub fn angle_flat(self) -> f32 {
-        self.angle_pointy() + DIRECTION_ANGLE_OFFSET_RAD
+        self.angle(HexOrientation::Flat)
     }
 
     #[inline]
@@ -322,7 +324,7 @@ impl EdgeDirection {
     ///
     /// See [`Self::angle_flat`] for *flat* hexagons
     pub fn angle_pointy(self) -> f32 {
-        self.angle_between(Self(0))
+        self.angle(HexOrientation::Pointy)
     }
 
     #[inline]
@@ -330,7 +332,11 @@ impl EdgeDirection {
     /// Returns the angle in radians of the given direction in the given
     /// `orientation`
     pub fn angle(self, orientation: HexOrientation) -> f32 {
-        self.angle_pointy() - orientation.angle_offset
+        let base = self.angle_to(Self(0));
+        match orientation {
+            HexOrientation::Pointy => base,
+            HexOrientation::Flat => base + DIRECTION_ANGLE_OFFSET_RAD,
+        }
     }
 
     #[inline]
@@ -338,9 +344,9 @@ impl EdgeDirection {
     /// Returns the angle in degrees of the given direction for *pointy*
     /// hexagons
     ///
-    /// See [`Self::angle_flat`] for *flat* hexagons
+    /// See [`Self::angle_pointy_degrees`] for *flat* hexagons
     pub fn angle_flat_degrees(self) -> f32 {
-        self.angle_pointy_degrees() + DIRECTION_ANGLE_OFFSET_DEGREES
+        self.angle_degrees(HexOrientation::Flat)
     }
 
     #[inline]
@@ -348,9 +354,9 @@ impl EdgeDirection {
     /// Returns the angle in degrees of the given direction for *pointy*
     /// hexagons
     ///
-    /// See [`Self::angle_flat`] for *flat* hexagons
+    /// See [`Self::angle_flat_degrees`] for *flat* hexagons
     pub fn angle_pointy_degrees(self) -> f32 {
-        self.angle_degrees_between(Self::default())
+        self.angle_degrees(HexOrientation::Pointy)
     }
 
     #[inline]
@@ -360,9 +366,10 @@ impl EdgeDirection {
     ///
     /// See [`Self::angle`] for radians angles
     pub fn angle_degrees(self, orientation: HexOrientation) -> f32 {
+        let base = self.angle_degrees_to(Self(0));
         match orientation {
-            HexOrientation::Pointy => self.angle_pointy_degrees(),
-            HexOrientation::Flat => self.angle_flat_degrees(),
+            HexOrientation::Pointy => base,
+            HexOrientation::Flat => base + DIRECTION_ANGLE_OFFSET_DEGREES,
         }
     }
     #[must_use]

--- a/src/direction/vertex_direction.rs
+++ b/src/direction/vertex_direction.rs
@@ -43,6 +43,24 @@ use std::{f32::consts::TAU, fmt::Debug};
 /// assert_eq!(direction >> 1, VertexDirection::FLAT_BOTTOM_RIGHT);
 /// assert_eq!(direction << 1, VertexDirection::FLAT_TOP_RIGHT);
 /// ```
+///
+/// ## Storage
+///
+/// Both [`EdgeDirection`] and [`VertexDirection`] store a u8 byte between 0 and
+/// 5 as following:
+///
+/// ```txt
+///           e1
+///       v2_____ v1
+///     e2 /     \ e0
+///       /       \
+///   v3 (         ) v0
+///       \       /
+///     e3 \_____/ e5
+///      v4   e5  v5
+/// ```
+///
+/// On pointy orientation the hexagon is shifted by 30 degrees clockwise
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -188,7 +206,7 @@ impl VertexDirection {
     /// Converts the direction to a hex coordinate
     #[must_use]
     #[inline]
-    pub const fn into_inner(self) -> Hex {
+    pub const fn into_hex(self) -> Hex {
         Hex::DIAGONAL_COORDS[self.0 as usize]
     }
 
@@ -559,14 +577,14 @@ impl VertexDirection {
 
 impl From<VertexDirection> for Hex {
     fn from(value: VertexDirection) -> Self {
-        value.into_inner()
+        value.into_hex()
     }
 }
 
 #[cfg(not(target_arch = "spirv"))]
 impl Debug for VertexDirection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let c = self.into_inner();
+        let c = self.into_hex();
         f.debug_struct("VertexDirection")
             .field("index", &self.0)
             .field("x", &c.x)

--- a/src/direction/vertex_direction.rs
+++ b/src/direction/vertex_direction.rs
@@ -70,6 +70,8 @@ use std::{f32::consts::TAU, fmt::Debug};
 pub struct VertexDirection(pub(crate) u8);
 
 impl VertexDirection {
+    /// Direction towards `X, -Y, -Z`
+    pub const X_NEG_Y_NEG_Z: Self = Self(0);
     /// Direction to (2, -1) or (2, -1, -1)
     ///
     /// Represents "Right" in flat orientation
@@ -87,6 +89,8 @@ impl VertexDirection {
     /// Represents "South West" in pointy orientation
     pub const POINTY_SOUTH_WEST: Self = Self(0);
 
+    /// Direction towards `X, -Y, Z`
+    pub const X_NEG_Y_Z: Self = Self(1);
     /// Direction to (1, -2) or (1, -2, 1)
     ///
     /// Represents "Top Right" in flat orientation
@@ -104,6 +108,8 @@ impl VertexDirection {
     /// Represents "North West" in pointy orientation
     pub const POINTY_NORTH_WEST: Self = Self(1);
 
+    /// Direction towards `-X, -Y, Z`
+    pub const NEG_X_NEG_Y: Self = Self(2);
     /// Direction to (-1, -1) or (-1, -1, 2)
     ///
     /// Represents "Top Left" in flat orientation
@@ -121,6 +127,8 @@ impl VertexDirection {
     /// Represents "North" in pointy orientation
     pub const POINTY_NORTH: Self = Self(2);
 
+    /// Direction towards `-X, Y, Z`
+    pub const NEG_X_Y_Z: Self = Self(3);
     /// Direction to (-2, 1) or (-2, 1, 1)
     ///
     /// Represents "Left" in flat orientation
@@ -138,6 +146,8 @@ impl VertexDirection {
     /// Represents "North East" in pointy orientation
     pub const POINTY_NORTH_EAST: Self = Self(3);
 
+    /// Direction towards `-X, Y, -Z`
+    pub const NEG_X_Y_NEG_Z: Self = Self(4);
     /// Direction to (-1, 2) or (-1, 2, -1)
     ///
     /// Represents "Bottom Left" in flat orientation
@@ -155,6 +165,8 @@ impl VertexDirection {
     /// Represents "South Easth" in pointy orientation
     pub const POINTY_SOUTH_EAST: Self = Self(4);
 
+    /// Direction towards `X, Y, -Z`
+    pub const X_Y: Self = Self(5);
     /// Direction to (1, 1) or (1, 1, -2)
     ///
     /// Represents "Bottom Right" in flat orientation

--- a/src/direction/vertex_direction.rs
+++ b/src/direction/vertex_direction.rs
@@ -329,7 +329,7 @@ impl VertexDirection {
     ///
     /// See [`Self::angle_flat`] for *flat* hexagons
     pub fn angle_flat_degrees(self) -> f32 {
-        self.angle_degrees_between(Self::default())
+        self.angle_degrees_between(Self(0))
     }
 
     #[inline]
@@ -347,7 +347,7 @@ impl VertexDirection {
     /// Returns the angle in radians of the given direction in the given
     /// `orientation`
     pub fn angle(self, orientation: HexOrientation) -> f32 {
-        self.angle_pointy() - orientation.angle_offset
+        self.angle_flat() - orientation.angle_offset
     }
 
     #[inline]

--- a/src/hex/grid/edge.rs
+++ b/src/hex/grid/edge.rs
@@ -16,7 +16,8 @@ pub struct GridEdge {
 }
 
 impl GridEdge {
-    /// Edges are equivalent if they have identical or flipped origin or direction
+    /// Edges are equivalent if they have identical or flipped origin or
+    /// direction
     #[must_use]
     pub fn equivalent(&self, other: &Self) -> bool {
         (self.origin == other.origin && self.direction == other.direction)

--- a/src/hex/grid/edge.rs
+++ b/src/hex/grid/edge.rs
@@ -125,3 +125,12 @@ impl Neg for GridEdge {
         self.const_neg()
     }
 }
+
+impl From<EdgeDirection> for GridEdge {
+    fn from(direction: EdgeDirection) -> Self {
+        Self {
+            origin: Hex::ZERO,
+            direction,
+        }
+    }
+}

--- a/src/hex/grid/edge.rs
+++ b/src/hex/grid/edge.rs
@@ -4,7 +4,10 @@ use std::ops::Neg;
 use super::GridVertex;
 
 /// Hexagonal grid orientated edge representation
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct GridEdge {
     /// The coordinate of the edge
     pub origin: Hex,
@@ -12,15 +15,14 @@ pub struct GridEdge {
     pub direction: EdgeDirection,
 }
 
-impl PartialEq for GridEdge {
-    // Edges are equal if they have identical or flipped origin or direction
-    fn eq(&self, other: &Self) -> bool {
+impl GridEdge {
+    /// Edges are equivalent if they have identical or flipped origin or direction
+    #[must_use]
+    pub fn equivalent(&self, other: &Self) -> bool {
         (self.origin == other.origin && self.direction == other.direction)
             || (self.origin == other.destination() && self.direction == other.direction.const_neg())
     }
-}
 
-impl GridEdge {
     #[inline]
     #[must_use]
     /// Returns the coordinate the edge id pointing to

--- a/src/hex/grid/edge.rs
+++ b/src/hex/grid/edge.rs
@@ -1,0 +1,127 @@
+use crate::{EdgeDirection, Hex};
+use std::ops::Neg;
+
+use super::GridVertex;
+
+/// Hexagonal grid orientated edge representation
+#[derive(Debug, Clone, Copy)]
+pub struct GridEdge {
+    /// The coordinate of the edge
+    pub origin: Hex,
+    /// The direction the edge points towards
+    pub direction: EdgeDirection,
+}
+
+impl PartialEq for GridEdge {
+    // Edges are equal if they have identical or flipped origin or direction
+    fn eq(&self, other: &Self) -> bool {
+        (self.origin == other.origin && self.direction == other.direction)
+            || (self.origin == other.destination() && self.direction == other.direction.const_neg())
+    }
+}
+
+impl GridEdge {
+    #[inline]
+    #[must_use]
+    /// Returns the coordinate the edge id pointing to
+    pub const fn destination(&self) -> Hex {
+        self.origin.add_dir(self.direction)
+    }
+
+    #[inline]
+    #[must_use]
+    /// Returns the two vertices making this edge in clockwise order
+    pub const fn vertices(&self) -> [GridVertex; 2] {
+        [
+            GridVertex {
+                origin: self.origin,
+                direction: self.direction.diagonal_ccw(),
+            },
+            GridVertex {
+                origin: self.origin,
+                direction: self.direction.diagonal_cw(),
+            },
+        ]
+    }
+
+    #[inline]
+    #[must_use]
+    /// Flips the edge, changing its `origin` to be the `destination` and
+    /// inverting its direction
+    pub const fn flipped(self) -> Self {
+        Self {
+            origin: self.destination(),
+            direction: self.direction.const_neg(),
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    /// Inverts the edge, now facing the opposite direction
+    pub const fn const_neg(self) -> Self {
+        Self {
+            direction: self.direction.const_neg(),
+            ..self
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    /// Returns the next edge in clockwise order
+    pub const fn clockwise(self) -> Self {
+        Self {
+            direction: self.direction.clockwise(),
+            ..self
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    /// Returns the next edge in counter clockwise order
+    pub const fn counter_clockwise(self) -> Self {
+        Self {
+            direction: self.direction.counter_clockwise(),
+            ..self
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    /// Rotates `self` clockwise by `offset` amount.
+    pub const fn rotate_cw(self, offset: u8) -> Self {
+        Self {
+            direction: self.direction.rotate_cw(offset),
+            ..self
+        }
+    }
+    #[inline]
+    #[must_use]
+    /// Rotates `self` counter clockwise by `offset` amount.
+    pub const fn rotate_ccw(self, offset: u8) -> Self {
+        Self {
+            direction: self.direction.rotate_ccw(offset),
+            ..self
+        }
+    }
+}
+
+impl Hex {
+    #[must_use]
+    #[inline]
+    /// Return all 6 edges of the coordinate
+    pub fn all_edges(self) -> [GridEdge; 6] {
+        EdgeDirection::ALL_DIRECTIONS.map(|direction| GridEdge {
+            origin: self,
+            direction,
+        })
+    }
+}
+
+impl Neg for GridEdge {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self::Output {
+        self.const_neg()
+    }
+}

--- a/src/hex/grid/mod.rs
+++ b/src/hex/grid/mod.rs
@@ -1,0 +1,5 @@
+mod edge;
+mod vertex;
+
+pub use edge::GridEdge;
+pub use vertex::GridVertex;

--- a/src/hex/grid/vertex.rs
+++ b/src/hex/grid/vertex.rs
@@ -140,3 +140,12 @@ impl Neg for GridVertex {
         self.const_neg()
     }
 }
+
+impl From<VertexDirection> for GridVertex {
+    fn from(direction: VertexDirection) -> Self {
+        Self {
+            origin: Hex::ZERO,
+            direction,
+        }
+    }
+}

--- a/src/hex/grid/vertex.rs
+++ b/src/hex/grid/vertex.rs
@@ -1,0 +1,142 @@
+use std::ops::Neg;
+
+use crate::{Hex, VertexDirection};
+
+use super::GridEdge;
+
+/// Hexagonal grid orientated vertex representation.
+#[derive(Debug, Clone, Copy)]
+pub struct GridVertex {
+    /// The coordinate of the edge
+    pub origin: Hex,
+    /// The direction the vertex points towards
+    pub direction: VertexDirection,
+}
+
+impl PartialEq for GridVertex {
+    fn eq(&self, other: &Self) -> bool {
+        let [cw, ccw] = [
+            Self {
+                origin: self.origin + self.direction.direction_cw(),
+                direction: self.direction.rotate_ccw(2),
+            },
+            Self {
+                origin: self.origin + self.direction.direction_ccw(),
+                direction: self.direction.rotate_cw(2),
+            },
+        ];
+        // identical
+        (self.origin == other.origin && self.direction == other.direction)
+            || (cw.origin == other.origin && cw.direction == other.direction)
+            || (ccw.origin == other.origin && ccw.direction == other.direction)
+    }
+}
+
+impl GridVertex {
+    #[inline]
+    #[must_use]
+    /// Returns the three connected coordinates in clockwise order
+    pub const fn coordinates(&self) -> [Hex; 3] {
+        [
+            self.origin,
+            self.origin.add_dir(self.direction.direction_ccw()),
+            self.origin.add_dir(self.direction.direction_cw()),
+        ]
+    }
+    #[inline]
+    #[must_use]
+    /// Returns the two destination coordinates in clockwise order
+    pub const fn destinations(&self) -> [Hex; 2] {
+        [
+            self.origin.add_dir(self.direction.direction_ccw()),
+            self.origin.add_dir(self.direction.direction_cw()),
+        ]
+    }
+
+    #[inline]
+    #[must_use]
+    /// Return the two adjacent edges sharing the same coordinate origin.
+    /// The edges are returned in clockwise order
+    pub const fn side_edges(&self) -> [GridEdge; 2] {
+        [
+            GridEdge {
+                origin: self.origin,
+                direction: self.direction.direction_ccw(),
+            },
+            GridEdge {
+                origin: self.origin,
+                direction: self.direction.direction_cw(),
+            },
+        ]
+    }
+
+    #[inline]
+    #[must_use]
+    /// Inverts the vertex, now facing the opposite direction
+    pub const fn const_neg(self) -> Self {
+        Self {
+            direction: self.direction.const_neg(),
+            ..self
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    /// Returns the next vertex in clockwise order
+    pub const fn clockwise(self) -> Self {
+        Self {
+            direction: self.direction.clockwise(),
+            ..self
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    /// Returns the next vertex in counter clockwise order
+    pub const fn counter_clockwise(self) -> Self {
+        Self {
+            direction: self.direction.counter_clockwise(),
+            ..self
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    /// Rotates `self` clockwise by `offset` amount.
+    pub const fn rotate_cw(self, offset: u8) -> Self {
+        Self {
+            direction: self.direction.rotate_cw(offset),
+            ..self
+        }
+    }
+    #[inline]
+    #[must_use]
+    /// Rotates `self` counter clockwise by `offset` amount.
+    pub const fn rotate_ccw(self, offset: u8) -> Self {
+        Self {
+            direction: self.direction.rotate_ccw(offset),
+            ..self
+        }
+    }
+}
+
+impl Hex {
+    /// Returns all vertices of the given coordinate
+    #[inline]
+    #[must_use]
+    pub fn all_vertices(self) -> [GridVertex; 6] {
+        VertexDirection::ALL_DIRECTIONS.map(|direction| GridVertex {
+            origin: self,
+            direction,
+        })
+    }
+}
+
+impl Neg for GridVertex {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self::Output {
+        self.const_neg()
+    }
+}

--- a/src/hex/grid/vertex.rs
+++ b/src/hex/grid/vertex.rs
@@ -5,7 +5,10 @@ use crate::{Hex, VertexDirection};
 use super::GridEdge;
 
 /// Hexagonal grid orientated vertex representation.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct GridVertex {
     /// The coordinate of the edge
     pub origin: Hex,
@@ -13,8 +16,11 @@ pub struct GridVertex {
     pub direction: VertexDirection,
 }
 
-impl PartialEq for GridVertex {
-    fn eq(&self, other: &Self) -> bool {
+impl GridVertex {
+    /// Checks if `self` and `rhs` are the same vertex, meaning either identical
+    /// or shared between adjacent coordinates
+    #[must_use]
+    pub fn equivalent(&self, other: &Self) -> bool {
         let [cw, ccw] = [
             Self {
                 origin: self.origin + self.direction.direction_cw(),
@@ -30,9 +36,7 @@ impl PartialEq for GridVertex {
             || (cw.origin == other.origin && cw.direction == other.direction)
             || (ccw.origin == other.origin && ccw.direction == other.direction)
     }
-}
 
-impl GridVertex {
     #[inline]
     #[must_use]
     /// Returns the three connected coordinates in clockwise order

--- a/src/hex/impls.rs
+++ b/src/hex/impls.rs
@@ -33,7 +33,7 @@ impl Add<EdgeDirection> for Hex {
 
     #[inline]
     fn add(self, rhs: EdgeDirection) -> Self::Output {
-        self.add(Self::from(rhs))
+        self.add_dir(rhs)
     }
 }
 
@@ -42,7 +42,7 @@ impl Add<VertexDirection> for Hex {
 
     #[inline]
     fn add(self, rhs: VertexDirection) -> Self::Output {
-        self.add(Self::from(rhs))
+        self.add_diag_dir(rhs)
     }
 }
 

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -600,7 +600,7 @@ impl Hex {
     /// Retrieves the hexagonal neighbor coordinates matching the given
     /// `direction`
     pub const fn neighbor_coord(direction: EdgeDirection) -> Self {
-        direction.into_inner()
+        direction.into_hex()
     }
 
     #[inline]
@@ -608,7 +608,7 @@ impl Hex {
     /// Retrieves the diagonal neighbor coordinates matching the given
     /// `direction`
     pub const fn diagonal_neighbor_coord(direction: VertexDirection) -> Self {
-        direction.into_inner()
+        direction.into_hex()
     }
 
     pub(crate) const fn add_dir(self, direction: EdgeDirection) -> Self {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -134,7 +134,8 @@ impl HexLayout {
 
 #[cfg(feature = "grid")]
 impl HexLayout {
-    /// Returns the  world coordinate of the two edge vertices in clockwise order
+    /// Returns the  world coordinate of the two edge vertices in clockwise
+    /// order
     #[must_use]
     pub fn edge_coordinates(&self, edge: crate::GridEdge) -> [Vec2; 2] {
         edge.vertices().map(|v| self.vertex_coordinates(v))

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -132,6 +132,23 @@ impl HexLayout {
     }
 }
 
+#[cfg(feature = "grid")]
+impl HexLayout {
+    /// Returns the  world coordinate of the two edge vertices in clockwise order
+    #[must_use]
+    pub fn edge_coordinates(&self, edge: crate::GridEdge) -> [Vec2; 2] {
+        edge.vertices().map(|v| self.vertex_coordinates(v))
+    }
+
+    /// Returns the world coordinate of the vertex
+    #[must_use]
+    pub fn vertex_coordinates(&self, vertex: crate::GridVertex) -> Vec2 {
+        let origin = self.hex_to_world_pos(vertex.origin);
+        let angle = vertex.direction.angle(self.orientation);
+        origin + Vec2::new(self.hex_size.x * angle.cos(), self.hex_size.y * angle.sin())
+    }
+}
+
 impl Default for HexLayout {
     fn default() -> Self {
         Self {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,4 +1,4 @@
-use crate::{orientation::SQRT_3, EdgeDirection, Hex, HexOrientation};
+use crate::{orientation::SQRT_3, Hex, HexOrientation, VertexDirection};
 use glam::Vec2;
 
 /// Hexagonal layout. This type is the bridge between your *world*/*pixel*
@@ -105,7 +105,7 @@ impl HexLayout {
 
     #[must_use]
     pub(crate) fn center_aligned_hex_corners(&self) -> [Vec2; 6] {
-        EdgeDirection::ALL_DIRECTIONS.map(|dir| {
+        VertexDirection::ALL_DIRECTIONS.map(|dir| {
             let angle = dir.angle(self.orientation);
             Vec2::new(self.hex_size.x * angle.cos(), self.hex_size.y * angle.sin())
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,9 @@ pub use glam::{IVec2, IVec3, Quat, Vec2, Vec3};
 #[doc(inline)]
 pub use hex::{hex, Hex, HexIterExt};
 #[doc(inline)]
+#[cfg(feature = "grid")]
+pub use hex::{GridEdge, GridVertex};
+#[doc(inline)]
 pub use layout::HexLayout;
 #[cfg(feature = "mesh")]
 pub use mesh::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@
 //! * `hexx = { version = "0.15", features = ["bevy_reflect"] }`
 //!
 //! `hexx` supports Face/Vertex/Edge [grid handling](https://www.redblobgames.com/grids/parts/#hexagon-coordinates)
-//! using `Hex` as Face, `GridVertex` as vertex and `GridEdge` as edge. To enable it add the
-//! following line to your `Cargo.toml`:
+//! using `Hex` as Face, `GridVertex` as vertex and `GridEdge` as edge. To
+//! enable it add the following line to your `Cargo.toml`:
 //!
 //! * `hexx = { version = "0.15", features = ["grid"] }`
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,12 @@
 //!
 //! * `hexx = { version = "0.15", features = ["bevy_reflect"] }`
 //!
+//! `hexx` supports Face/Vertex/Edge [grid handling](https://www.redblobgames.com/grids/parts/#hexagon-coordinates)
+//! using `Hex` as Face, `GridVertex` as vertex and `GridEdge` as edge. To enable it add the
+//! following line to your `Cargo.toml`:
+//!
+//! * `hexx = { version = "0.15", features = ["grid"] }`
+//!
 //! ## Features
 //!
 //! `hexx` provides the [`Hex`] coordinates with:

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -22,7 +22,7 @@ pub(crate) const BASE_FACING: Vec3 = Vec3::Y;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct InsetOptions {
-    /// If set to `true``the original downscaled face will be kept
+    /// If set to `true` the original downscaled face will be kept
     pub keep_inner_face: bool,
     /// Scale factor
     pub scale: f32,

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -1,21 +1,17 @@
 use std::ops::Deref;
 
-use crate::{direction::angles::DIRECTION_ANGLE_OFFSET_RAD, EdgeDirection};
-
 pub(crate) const SQRT_3: f32 = 1.732_050_8;
 
 /// Pointy orientation matrices and offset
 const POINTY_ORIENTATION: HexOrientationData = HexOrientationData {
     forward_matrix: [SQRT_3, SQRT_3 / 2.0, 0.0, 3.0 / 2.0],
     inverse_matrix: [SQRT_3 / 3.0, -1.0 / 3.0, 0.0, 2.0 / 3.0],
-    angle_offset: DIRECTION_ANGLE_OFFSET_RAD, // 30 degrees
 };
 
 /// Flat orientation matrices and offset
 const FLAT_ORIENTATION: HexOrientationData = HexOrientationData {
     forward_matrix: [3.0 / 2.0, 0.0, SQRT_3 / 2.0, SQRT_3],
     inverse_matrix: [2.0 / 3.0, 0.0, -1.0 / 3.0, SQRT_3 / 3.0],
-    angle_offset: 0.0, // 0 degrees
 };
 
 /// [`HexOrientation`] inner data, retrieved by
@@ -42,8 +38,6 @@ pub struct HexOrientationData {
     pub(crate) forward_matrix: [f32; 4],
     /// Matrix used to compute world/pixel coordinates to hexagonal coordinates
     pub(crate) inverse_matrix: [f32; 4],
-    /// orientation offset in radians
-    pub(crate) angle_offset: f32,
 }
 
 /// Hexagonal orientation, either *Pointy-Topped* or *Flat-Topped*
@@ -59,14 +53,6 @@ pub enum HexOrientation {
 }
 
 impl HexOrientation {
-    #[must_use]
-    #[inline]
-    /// Computes the angle in radians of the given `direction` in the current
-    /// orientation
-    pub fn direction_angle(self, direction: EdgeDirection) -> f32 {
-        direction.angle(self)
-    }
-
     #[must_use]
     #[inline]
     /// Returns the orientation inner data, rotation angle and matrices


### PR DESCRIPTION
> Adresses #153

- Added `GridVertex`  and `GridEdge` utility structs representing **orientated** edge and vertices.
- Fixed issues with angle calculations
- Cleaned some leftovers from #156 
- Updated `hex_grid` example using the new edges to draw a gizmo on the hovered tile