### PR TITLE
2D Vec storage for hex maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `HexagonalMap` storage structure for dense, hexagon shaped maps (#163)
 * Update `field_of_movement` to use `HexagonalMap` (#163)
+* Added `shapes::rombus` (#163)
 
 ## 0.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* Added `HexagonalMap` storage structure for dense, hexagon shaped maps (#163)
+* Update `field_of_movement` to use `HexagonalMap` (#163)
+
 ## 0.16.1
 
 * Derived `PartialEq` and `Eq` for `HexBounds` (#160)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,5 +138,9 @@ harness = false
 name = "rings"
 harness = false
 
+[[bench]]
+name = "maps"
+harness = false
+
 [profile.dev]
 opt-level = 1

--- a/benches/maps.rs
+++ b/benches/maps.rs
@@ -1,0 +1,36 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use hexx::*;
+use std::collections::HashMap;
+
+pub fn map_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Hex Map");
+    group.significance_level(0.1).sample_size(100);
+
+    let get_value = |h: Hex| h.length();
+
+    for dist in [10, 50, 100, 300] {
+        let hash_map: HashMap<_, _> = Hex::ZERO
+            .range(dist)
+            .map(|hex| (hex, get_value(hex)))
+            .collect();
+        group.bench_with_input(BenchmarkId::new("HashMap", dist), &dist, |b, dist| {
+            b.iter(|| {
+                for c in black_box(Hex::ZERO).range(*dist) {
+                    hash_map.get(&c).unwrap();
+                }
+            })
+        });
+        let hex_map = HexagonalMap::new(Hex::ZERO, dist, get_value);
+        group.bench_with_input(BenchmarkId::new("HexagonalMap", dist), &dist, |b, dist| {
+            b.iter(|| {
+                for c in black_box(Hex::ZERO).range(*dist) {
+                    hex_map.get(c).unwrap();
+                }
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, map_benchmark);
+criterion_main!(benches);

--- a/examples/field_of_movement.rs
+++ b/examples/field_of_movement.rs
@@ -1,7 +1,7 @@
 use bevy::{
     prelude::*,
     render::{mesh::Indices, render_asset::RenderAssetUsages, render_resource::PrimitiveTopology},
-    utils::{HashMap, HashSet},
+    utils::HashSet,
     window::PrimaryWindow,
 };
 use hexx::{algorithms::field_of_movement, *};
@@ -30,7 +30,7 @@ type Cost = Option<u32>;
 
 #[derive(Debug, Resource)]
 struct HexGrid {
-    pub entities: HashMap<Hex, (Cost, Entity)>,
+    pub entities: HexagonalMap<(Cost, Entity)>,
     pub reachable_entities: HashSet<Entity>,
     pub layout: HexLayout,
 }
@@ -62,11 +62,11 @@ fn handle_input(
         *current = hex_pos;
 
         let field_of_movement =
-            field_of_movement(hex_pos, BUDGET, |h| grid.entities.get(&h).and_then(|c| c.0));
+            field_of_movement(hex_pos, BUDGET, |h| grid.entities.get(h).and_then(|c| c.0));
 
         let reachable_entities: HashSet<_> = field_of_movement
             .into_iter()
-            .filter_map(|h| grid.entities.get(&h).map(|&(_, ent)| ent))
+            .filter_map(|h| grid.entities.get(h).map(|&(_, ent)| ent))
             .collect();
         for (entity, mut transform) in tile_transforms.iter_mut() {
             if reachable_entities.contains(&entity) {
@@ -97,35 +97,31 @@ fn setup_grid(
 
     let mut rng = rand::thread_rng();
 
-    let entities = Hex::ZERO
-        .spiral_range(0..=MAP_RADIUS)
-        .enumerate()
-        .map(|(_i, coord)| {
-            let cost = rng.gen_range(0..=3);
-            let pos = layout.hex_to_world_pos(coord);
-            let material = match cost {
-                0 => plains_mat.clone(),
-                1 => forest_mat.clone(),
-                2 => desert_mat.clone(),
-                3 => wall_mat.clone(),
-                _ => unreachable!(),
-            };
-            let cost = if (0..3).contains(&cost) {
-                Some(cost)
-            } else {
-                None
-            };
-            let entity = commands
-                .spawn(ColorMesh2dBundle {
-                    mesh: mesh.clone().into(),
-                    material,
-                    transform: Transform::from_xyz(pos.x, pos.y, 0.0),
-                    ..default()
-                })
-                .id();
-            (coord, (cost, entity))
-        })
-        .collect();
+    let entities = HexagonalMap::new(Hex::ZERO, MAP_RADIUS, |coord| {
+        let cost = rng.gen_range(0..=3);
+        let pos = layout.hex_to_world_pos(coord);
+        let material = match cost {
+            0 => plains_mat.clone(),
+            1 => forest_mat.clone(),
+            2 => desert_mat.clone(),
+            3 => wall_mat.clone(),
+            _ => unreachable!(),
+        };
+        let cost = if (0..3).contains(&cost) {
+            Some(cost)
+        } else {
+            None
+        };
+        let entity = commands
+            .spawn(ColorMesh2dBundle {
+                mesh: mesh.clone().into(),
+                material,
+                transform: Transform::from_xyz(pos.x, pos.y, 0.0),
+                ..default()
+            })
+            .id();
+        (cost, entity)
+    });
     commands.insert_resource(HexGrid {
         entities,
         reachable_entities: Default::default(),

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -66,6 +66,19 @@ impl HexBounds {
         Self { center, radius }
     }
 
+    /// Computes the bounds for `radius` with all coordinates
+    /// being positive.
+    ///
+    /// This can be used for efficient map storage in a 2D vector
+    /// disallowing negative coordinates
+    #[inline]
+    #[must_use]
+    #[allow(clippy::cast_possible_wrap)]
+    pub const fn positive_radius(radius: u32) -> Self {
+        let center = Hex::splat(radius as i32);
+        Self { center, radius }
+    }
+
     #[inline]
     #[must_use]
     /// Checks if `rhs` is in bounds
@@ -182,5 +195,16 @@ mod tests {
 
         assert_eq!(map.wrap(Hex::new(2, 3)), Hex::new(0, 0)); // mirror
         assert_eq!(map.wrap(Hex::new(4, 6)), Hex::new(0, 0));
+    }
+
+    #[test]
+    fn positive_radius() {
+        for radius in 0..100_u32 {
+            let bounds = HexBounds::positive_radius(radius);
+            let coords = bounds.all_coords();
+            let fails: Vec<_> = coords.filter(|c| c.x < 0 || c.y < 0).collect();
+            println!("{fails:#?}");
+            assert!(fails.is_empty());
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,4 +268,3 @@ pub use mesh::*;
 pub use orientation::HexOrientation;
 #[doc(inline)]
 pub use storage::HexagonalMap;
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,8 @@ pub mod mesh;
 pub mod orientation;
 /// Map shapes generation functions
 pub mod shapes;
+/// Map Storage utility
+pub mod storage;
 
 #[doc(inline)]
 pub use bounds::HexBounds;
@@ -264,3 +266,6 @@ pub use layout::HexLayout;
 pub use mesh::*;
 #[doc(inline)]
 pub use orientation::HexOrientation;
+#[doc(inline)]
+pub use storage::HexagonalMap;
+

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -33,6 +33,18 @@ pub fn hexagon(center: Hex, radius: u32) -> impl ExactSizeIterator<Item = Hex> {
     center.range(radius)
 }
 
+/// Generates a Rombus from `point` of `rows` in y and `columns` in `x`
+#[must_use]
+#[allow(clippy::cast_possible_wrap)]
+pub fn rombus(point: Hex, rows: u32, columns: u32) -> impl ExactSizeIterator<Item = Hex> {
+    ExactSizeHexIterator {
+        iter: (0..rows).flat_map(move |y| {
+            (0..columns).map(move |x| point.const_add(Hex::new(x as i32, y as i32)))
+        }),
+        count: (rows * columns) as usize,
+    }
+}
+
 /// Generates a rectangle with the given bounds for "pointy topped" hexagons.
 ///
 /// The function takes four offsets as `[left, right, top, bottom]`.
@@ -98,6 +110,18 @@ mod tests {
             for max in 0..=30 {
                 let iter = parallelogram(Hex::splat(min), Hex::splat(min + max));
                 assert_eq!(iter.len(), iter.count());
+            }
+        }
+    }
+
+    #[test]
+    fn rombus_test() {
+        for columns in 0..=30 {
+            for rows in 0..=30 {
+                for p in Hex::ZERO.range(10) {
+                    let iter = rombus(p, rows, columns);
+                    assert_eq!(iter.len(), iter.count());
+                }
             }
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,184 @@
+use crate::{Hex, HexBounds};
+use std::{
+    ops::{Index, IndexMut},
+    slice::{Iter, IterMut},
+};
+
+/// [`Vec`] Based storage for hexagonal maps.
+///
+/// > See [this article](https://www.redblobgames.com/grids/hexagons/#map-storage)
+///
+/// [`HexagonalMap`] is made for _hexagonal_ large _dense_ maps, utilizing some tricks
+/// to map [`Hex`] coordinate to a positive 2D array.
+///
+/// It can be used only if:
+/// - The map is an hexagon shape
+/// - The map is _dense_
+/// - No coordinate will be added or removed from the map
+///
+/// If your use case doesn't match all of the above, use a [`HashMap`] instead
+pub struct HexagonalMap<T> {
+    inner: Vec<Vec<T>>,
+    bounds: HexBounds,
+}
+
+impl<T> HexagonalMap<T> {
+    ///
+    #[inline]
+    #[must_use]
+    #[allow(clippy::cast_possible_wrap)]
+    pub fn new(center: Hex, radius: u32, values: impl Fn(Hex) -> T) -> Self {
+        let bounds = HexBounds::new(center, radius);
+        let range = radius as i32;
+        let inner = (-range..=range)
+            .map(|y| {
+                let x_min = i32::max(-range, -y - range);
+                let x_max = i32::min(range, range - y);
+                (x_min..=x_max)
+                    .map(|x| {
+                        let coord = center.const_add(Hex::new(x, y));
+                        values(coord)
+                    })
+                    .collect()
+            })
+            .collect();
+        Self { inner, bounds }
+    }
+
+    #[inline]
+    #[must_use]
+    /// Returns the associated coordinate bounds
+    pub const fn bounds(&self) -> &HexBounds {
+        &self.bounds
+    }
+
+    #[allow(clippy::cast_possible_wrap)]
+    const fn offset(&self) -> Hex {
+        Hex::splat(self.bounds.radius as i32).const_sub(self.bounds.center)
+    }
+
+    fn hex_to_idx(&self, idx: Hex) -> Option<[usize; 2]> {
+        let key = idx + self.offset();
+        let Ok(x) = u32::try_from(key.x) else {
+            return None;
+        };
+        let Ok(y) = u32::try_from(key.y) else {
+            return None;
+        };
+        Some([
+            y as usize,
+            x.saturating_sub(self.bounds.radius.saturating_sub(y)) as usize,
+        ])
+    }
+
+    #[must_use]
+    /// Returns a reference the stored value associated with `idx`.
+    /// Returns `None` if `idx` is out of bounds
+    pub fn get(&self, idx: Hex) -> Option<&T> {
+        let [y, x] = self.hex_to_idx(idx)?;
+        self.inner.get(y).and_then(|v| v.get(x))
+    }
+
+    /// Returns a mutable reference the stored value associated with `idx`.
+    /// Returns `None` if `idx` is out of bounds
+    #[must_use]
+    pub fn get_mut(&mut self, idx: Hex) -> Option<&mut T> {
+        let [y, x] = self.hex_to_idx(idx)?;
+        self.inner.get_mut(y).and_then(|v| v.get_mut(x))
+    }
+
+    /// Returns an iterator over the storage, in `y` order
+    pub fn iter(&self) -> Iter<Vec<T>> {
+        self.inner.iter()
+    }
+
+    /// Returns an iterator over the storage, in `y` order
+    pub fn iter_mut(&mut self) -> IterMut<Vec<T>> {
+        self.inner.iter_mut()
+    }
+}
+
+impl<T> Index<Hex> for HexagonalMap<T> {
+    type Output = T;
+
+    fn index(&self, index: Hex) -> &Self::Output {
+        self.get(index).unwrap()
+    }
+}
+
+impl<T> Index<&Hex> for HexagonalMap<T> {
+    type Output = T;
+
+    fn index(&self, index: &Hex) -> &Self::Output {
+        self.get(*index).unwrap()
+    }
+}
+
+impl<T> IndexMut<Hex> for HexagonalMap<T> {
+    fn index_mut(&mut self, index: Hex) -> &mut Self::Output {
+        self.get_mut(index).unwrap()
+    }
+}
+
+impl<T> IndexMut<&Hex> for HexagonalMap<T> {
+    fn index_mut(&mut self, index: &Hex) -> &mut Self::Output {
+        self.get_mut(*index).unwrap()
+    }
+}
+
+impl<T> IntoIterator for HexagonalMap<T> {
+    type Item = Vec<T>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a HexagonalMap<T> {
+    type Item = &'a Vec<T>;
+    type IntoIter = Iter<'a, Vec<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut HexagonalMap<T> {
+    type Item = &'a mut Vec<T>;
+    type IntoIter = IterMut<'a, Vec<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::utils::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn validity() {
+        for center in Hex::ZERO.range(20) {
+            for radius in 0_u32..25 {
+                let expected: HashMap<Hex, usize> = center
+                    .range(radius)
+                    .enumerate()
+                    .map(|(i, h)| (h, i))
+                    .collect();
+
+                let map = HexagonalMap::new(center, radius, |h| expected[&h]);
+
+                for (k, v) in &expected {
+                    assert_eq!(*v, map[k]);
+                }
+
+                for k in map.bounds().all_coords() {
+                    assert_eq!(map[k], expected[&k]);
+                }
+            }
+        }
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,6 @@
 use crate::{Hex, HexBounds};
 use std::{
+    fmt,
     ops::{Index, IndexMut},
     slice::{Iter, IterMut},
 };
@@ -27,7 +28,7 @@ impl<T> HexagonalMap<T> {
     #[inline]
     #[must_use]
     #[allow(clippy::cast_possible_wrap)]
-    pub fn new(center: Hex, radius: u32, values: impl Fn(Hex) -> T) -> Self {
+    pub fn new(center: Hex, radius: u32, mut values: impl FnMut(Hex) -> T) -> Self {
         let bounds = HexBounds::new(center, radius);
         let range = radius as i32;
         let inner = (-range..=range)
@@ -150,6 +151,30 @@ impl<'a, T> IntoIterator for &'a mut HexagonalMap<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter_mut()
+    }
+}
+
+impl<T> fmt::Debug for HexagonalMap<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HexagonalMap")
+            .field("bounds", &self.bounds)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<T> Clone for HexagonalMap<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            bounds: self.bounds,
+        }
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,6 +18,8 @@ use std::{
 /// - No coordinate will be added or removed from the map
 ///
 /// If your use case doesn't match all of the above, use a [`HashMap`] instead
+///
+/// [`HashMap`]: std::collections::HashMap
 pub struct HexagonalMap<T> {
     inner: Vec<Vec<T>>,
     bounds: HexBounds,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -9,8 +9,8 @@ use std::{
 ///
 /// > See [this article](https://www.redblobgames.com/grids/hexagons/#map-storage)
 ///
-/// [`HexagonalMap`] is made for _hexagonal_ large _dense_ maps, utilizing some tricks
-/// to map [`Hex`] coordinate to a positive 2D array.
+/// [`HexagonalMap`] is made for _hexagonal_ large _dense_ maps, utilizing some
+/// tricks to map [`Hex`] coordinate to a positive 2D array.
 ///
 /// It can be used only if:
 /// - The map is an hexagon shape


### PR DESCRIPTION
# Work done

Added a storage optimized `HexagonalMap` utilizing some tricks to be able to store hex maps in a 2d vector instead on having to rely on hashmaps.

> See https://www.redblobgames.com/grids/hexagons/#map-storage

## Usage

This implementation only supports:
- **Dense**
- Hexagon-shaped
- Fixed sized

storage.

This can be useful for large hexagon shaped maps, as well as for chunk based maps, chunking would usually be of hexagonal shape.

## TODO

- [x] Benchmark
- [x] Usage in an example
- [x] Changelog