### PR TITLE
to/from_u64: explicitly convert to little-endian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * Added `Hex::as_u64` and `Hex::from_u64`
+  * Both are now little-endian
 
 ## 0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 * Added `Hex::as_u64` and `Hex::from_u64`
-  * Both are now little-endian
+  * now explicitly converted to/from little-endian if they weren't already
 
 ## 0.17.0
 

--- a/src/hex/convert.rs
+++ b/src/hex/convert.rs
@@ -60,8 +60,8 @@ impl From<IVec2> for Hex {
 impl Hex {
     /// Unpack from a [`u64`].
     /// [x][`Hex::x`] is read from the most signifigant 32 bits; [y][`Hex::y`]
-    /// is read from the least signifigant 32 bits. Intended to be used with
-    /// [`Hex::as_u64`].
+    /// is read from the least signifigant 32 bits. The fields are
+    /// little-endian. Intended to be used with [`Hex::as_u64`].
     ///
     /// # Example
     ///
@@ -74,16 +74,16 @@ impl Hex {
     #[must_use]
     #[doc(alias = "unpack")]
     pub const fn from_u64(value: u64) -> Self {
-        let x = (value >> 32) as i32;
-        let y = (value & 0xFFFF_FFFF) as i32;
+        let x = i32::from_le((value >> 32) as i32);
+        let y = i32::from_le((value & 0xFFFF_FFFF) as i32);
         Self::new(x, y)
     }
 
     /// Pack into a [`u64`].
     /// [x][`Hex::x`] is placed in the most signifigant 32 bits; [y][`Hex::y`]
     /// is placed in the least signifigant 32 bits. Can be used as a sort
-    /// key, or for saving in a binary format. Intended to be used with
-    /// [`Hex::from_u64`].
+    /// key, or for saving in a binary format. The fields are little-endian.
+    /// Intended to be used with [`Hex::from_u64`].
     ///
     /// # Example
     ///
@@ -97,8 +97,8 @@ impl Hex {
     #[allow(clippy::cast_sign_loss)]
     #[doc(alias = "pack")]
     pub const fn as_u64(self) -> u64 {
-        let high = (self.x as u32 as u64) << 32;
-        let low = self.y as u32 as u64;
+        let high = (self.x.to_le() as u32 as u64) << 32;
+        let low = self.y.to_le() as u32 as u64;
         high | low
     }
 }


### PR DESCRIPTION
Someone might send these across the network... to an [IBM System/390](https://en.wikipedia.org/wiki/IBM_System%2F390) or a spacecraft running [LEON](https://en.wikipedia.org/wiki/LEON). Will that literally ever happen? probably not. But now the byte order won't get messed up!