### PR TITLE
fix: CI issue with cargo test --doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Fix: CI failures with `dynamic_linking` (#184)
 * Bump `bevy` dependency to 0.15 (#181, #182)
 * Bump `glam` dependency to 0.29 (#181)
 * Bump `bevy_egui` dev dependency to `0.31` (#180, #181)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,6 @@ features = [
     "bevy_window",
     "bevy_winit",
     "default_font",
-    # Faster compilation
-    "dynamic_linking",
     "multi_threaded",
     "png",
     "tonemapping_luts",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@
 //! If you want to generate 3D hexagonal mesh and use it in
 //! [bevy](bevyengine.org) you may do it this way:
 //!
-//!```ignore
+//!```rust
 //! use bevy::{
 //!     prelude::Mesh,
 //!     render::{


### PR DESCRIPTION
So as it turns out, `dynamic_linking` no longer works with `cargo test --doc`. Have been talking back and forth on Bevy discord about it, not sure if it's resolveable but removing the feature at least allows CI to pass.

I'll leave it up to you if you'd prefer to create a profile just for doctests :slightly_smiling_face: 

Fixes #183 