### PR TITLE
feat: HexLayout has a single scale field for axis management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - `inverse_transform_vector`
   - `invert_x`
   - `invert_y`
+* Added `world_unit_vector` methods to `EdgeDirection` and `VertexDirection` (#190)
 
 ## 0.19.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@
   take a new `HexOrientation` parameter (#189)
 * (**BREAKING**) `HexLayout` Y axis is no longer inverted by default (#187)
 * `HexLayout` builder patter (#187)
-* (**BREAKING**) `HexLayout` removed the `invert_x` and `invert_y` fields (#189)
-* (**BREAKING**) `HexLayout` `hex_size` field is now `scale` (#189)
+* (**BREAKING**) `HexLayout` removed the `invert_x` and `invert_y` fields (#190)
+* (**BREAKING**) `HexLayout` `hex_size` field is now `scale` (#190)
+* Added the following `HexLayout` methods: (#190)
+  - `transform_point`
+  - `transform_vector`
+  - `inverse_transform_point`
+  - `inverse_transform_vector`
+  - `invert_x`
+  - `invert_y`
 
 ## 0.19.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   take a new `HexOrientation` parameter (#189)
 * (**BREAKING**) `HexLayout` Y axis is no longer inverted by default (#187)
 * `HexLayout` builder patter (#187)
+* (**BREAKING**) `HexLayout` removed the `invert_x` and `invert_y` fields (#189)
+* (**BREAKING**) `HexLayout` `hex_size` field is now `scale` (#189)
 
 ## 0.19.1
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@
 
  // Define your layout
  let layout = HexLayout {
-     hex_size: Vec2::new(1.0, 1.0),
+     scale: Vec2::new(1.0, 1.0),
      orientation: HexOrientation::Flat,
      ..Default::default()
  };

--- a/examples/3d_columns.rs
+++ b/examples/3d_columns.rs
@@ -60,7 +60,7 @@ fn setup_grid(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     // materials

--- a/examples/3d_picking.rs
+++ b/examples/3d_picking.rs
@@ -54,7 +54,7 @@ fn setup_grid(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     // materials

--- a/examples/a_star.rs
+++ b/examples/a_star.rs
@@ -48,7 +48,7 @@ fn setup_grid(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     let mesh = meshes.add(hexagonal_plane(&layout));

--- a/examples/chunks.rs
+++ b/examples/chunks.rs
@@ -35,7 +35,7 @@ fn setup_grid(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     // materials

--- a/examples/field_of_movement.rs
+++ b/examples/field_of_movement.rs
@@ -87,7 +87,7 @@ fn setup_grid(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     let mesh = meshes.add(hexagonal_plane(&layout));

--- a/examples/field_of_view.rs
+++ b/examples/field_of_view.rs
@@ -48,7 +48,7 @@ fn setup_grid(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     let mesh = meshes.add(hexagonal_plane(&layout));

--- a/examples/hex_area.rs
+++ b/examples/hex_area.rs
@@ -55,16 +55,14 @@ fn setup_grid(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let flat_layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         orientation: HexOrientation::Flat,
         origin: Vec2::new(-480.0, 0.0),
-        ..default()
     };
     let pointy_layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         orientation: HexOrientation::Pointy,
         origin: Vec2::new(480.0, 0.0),
-        ..default()
     };
     // materials
     let area_material = materials.add(Color::Srgba(GOLD));

--- a/examples/hex_grid.rs
+++ b/examples/hex_grid.rs
@@ -64,7 +64,7 @@ fn setup_grid(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     // materials

--- a/examples/merged_columns.rs
+++ b/examples/merged_columns.rs
@@ -66,7 +66,7 @@ fn setup_grid(
         commands.entity(map.0).despawn_recursive();
     }
     let layout = HexLayout {
-        hex_size: settings.hex_size,
+        scale: settings.hex_size,
         ..default()
     };
     // Materials shouldn't be added to assets every time, this is just to keep the

--- a/examples/mesh_builder.rs
+++ b/examples/mesh_builder.rs
@@ -266,8 +266,8 @@ fn gizmos(
     // Local axis
     let mut transform = *transform;
     transform.scale.y += params.height / 2.0;
-    transform.scale.x += info.layout.hex_size.x;
-    transform.scale.z += info.layout.hex_size.y;
+    transform.scale.x += info.layout.scale.x;
+    transform.scale.z += info.layout.scale.y;
     transform.scale *= params.scale;
     draw.axes(transform, 1.0);
 }

--- a/examples/scroll_map.rs
+++ b/examples/scroll_map.rs
@@ -42,7 +42,7 @@ fn setup_grid(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     let mesh = meshes.add(hexagonal_plane(&layout));

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -84,7 +84,7 @@ impl Shape {
 pub fn setup(mut commands: Commands, mut mats: ResMut<Assets<ColorMaterial>>) {
     commands.spawn(Camera2d);
     let layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     let mat = mats.add(Color::WHITE);
@@ -111,6 +111,10 @@ fn show_ui(world: &mut World) {
             ui.horizontal(|ui| {
                 ui.label("Orientation");
                 bevy_inspector::ui_for_value(&mut map.layout.orientation, ui, world);
+            });
+            ui.horizontal(|ui| {
+                ui.label("scale");
+                bevy_inspector::ui_for_value(&mut map.layout.scale, ui, world);
             });
         });
 

--- a/examples/sprite_sheet.rs
+++ b/examples/sprite_sheet.rs
@@ -40,7 +40,7 @@ fn setup_grid(
     let atlas_layout = atlas_layouts.add(atlas_layout);
     let layout = HexLayout {
         orientation: HexOrientation::Pointy,
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     let sprite_size = layout.rect_size();

--- a/examples/wrap_map.rs
+++ b/examples/wrap_map.rs
@@ -46,7 +46,7 @@ fn setup_grid(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     let layout = HexLayout {
-        hex_size: HEX_SIZE,
+        scale: HEX_SIZE,
         ..default()
     };
     let mesh = meshes.add(hexagonal_plane(&layout));

--- a/src/direction/edge_direction.rs
+++ b/src/direction/edge_direction.rs
@@ -387,7 +387,8 @@ impl EdgeDirection {
     /// Returns the unit vector of the direction in the given `orientation`.
     ///
     /// The vector is normalized and in local hex space. To use within a
-    /// [`HexLayout`] use [`HexLayout::transform_vector`] or [`world_unit_vector`]
+    /// [`HexLayout`] use [`HexLayout::transform_vector`] or
+    /// [`Self::world_unit_vector`]
     pub fn unit_vector(self, orientation: HexOrientation) -> Vec2 {
         let angle = self.angle(orientation);
         Vec2::new(angle.cos(), angle.sin())
@@ -398,7 +399,7 @@ impl EdgeDirection {
     /// Returns the unit vector of the direction in the given `layout`.
     ///
     /// The vector is provided in pixel/workd space. To use in local hex
-    /// space use [`unit_vector`]
+    /// space use [`Self::unit_vector`]
     pub fn world_unit_vector(self, layout: &HexLayout) -> Vec2 {
         let vector = self.unit_vector(layout.orientation);
         layout.transform_vector(vector)

--- a/src/direction/edge_direction.rs
+++ b/src/direction/edge_direction.rs
@@ -3,7 +3,7 @@ use crate::{
         DIRECTION_ANGLE_DEGREES, DIRECTION_ANGLE_OFFSET_DEGREES, DIRECTION_ANGLE_OFFSET_RAD,
         DIRECTION_ANGLE_RAD,
     },
-    Hex, HexOrientation, VertexDirection,
+    Hex, HexLayout, HexOrientation, VertexDirection,
 };
 use glam::Vec2;
 use std::{f32::consts::TAU, fmt::Debug};
@@ -387,10 +387,21 @@ impl EdgeDirection {
     /// Returns the unit vector of the direction in the given `orientation`.
     ///
     /// The vector is normalized and in local hex space. To use within a
-    /// [`HexLayout`] use [`HexLayout::transform_vector`]
+    /// [`HexLayout`] use [`HexLayout::transform_vector`] or [`world_unit_vector`]
     pub fn unit_vector(self, orientation: HexOrientation) -> Vec2 {
         let angle = self.angle(orientation);
         Vec2::new(angle.cos(), angle.sin())
+    }
+
+    #[inline]
+    #[must_use]
+    /// Returns the unit vector of the direction in the given `layout`.
+    ///
+    /// The vector is provided in pixel/workd space. To use in local hex
+    /// space use [`unit_vector`]
+    pub fn world_unit_vector(self, layout: &HexLayout) -> Vec2 {
+        let vector = self.unit_vector(layout.orientation);
+        layout.transform_vector(vector)
     }
 
     #[inline]

--- a/src/direction/edge_direction.rs
+++ b/src/direction/edge_direction.rs
@@ -384,7 +384,10 @@ impl EdgeDirection {
 
     #[inline]
     #[must_use]
-    /// Returns the unit vector of the direction in the given `orientation`
+    /// Returns the unit vector of the direction in the given `orientation`.
+    ///
+    /// The vector is normalized and in local hex space. To use within a
+    /// [`HexLayout`] use [`HexLayout::transform_vector`]
     pub fn unit_vector(self, orientation: HexOrientation) -> Vec2 {
         let angle = self.angle(orientation);
         Vec2::new(angle.cos(), angle.sin())

--- a/src/direction/vertex_direction.rs
+++ b/src/direction/vertex_direction.rs
@@ -388,7 +388,8 @@ impl VertexDirection {
     /// Returns the unit vector of the direction in the given `orientation`
     ///
     /// The vector is normalized and in local hex space. To use within a
-    /// [`HexLayout`] use [`HexLayout::transform_vector`] or [`world_unit_vector`]
+    /// [`HexLayout`] use [`HexLayout::transform_vector`] or
+    /// [`Self::world_unit_vector`]
     pub fn unit_vector(self, orientation: HexOrientation) -> Vec2 {
         let angle = self.angle(orientation);
         Vec2::new(angle.cos(), angle.sin())
@@ -399,7 +400,7 @@ impl VertexDirection {
     /// Returns the unit vector of the direction in the given `layout`.
     ///
     /// The vector is provided in pixel/workd space. To use in local hex
-    /// space use [`unit_vector`]
+    /// space use [`Self::unit_vector`]
     pub fn world_unit_vector(self, layout: &HexLayout) -> Vec2 {
         let vector = self.unit_vector(layout.orientation);
         layout.transform_vector(vector)

--- a/src/direction/vertex_direction.rs
+++ b/src/direction/vertex_direction.rs
@@ -3,7 +3,7 @@ use crate::{
         DIRECTION_ANGLE_DEGREES, DIRECTION_ANGLE_OFFSET_DEGREES, DIRECTION_ANGLE_OFFSET_RAD,
         DIRECTION_ANGLE_RAD,
     },
-    EdgeDirection, Hex, HexOrientation,
+    EdgeDirection, Hex, HexLayout, HexOrientation,
 };
 use glam::Vec2;
 use std::{f32::consts::TAU, fmt::Debug};
@@ -388,10 +388,21 @@ impl VertexDirection {
     /// Returns the unit vector of the direction in the given `orientation`
     ///
     /// The vector is normalized and in local hex space. To use within a
-    /// [`HexLayout`] use [`HexLayout::transform_vector`]
+    /// [`HexLayout`] use [`HexLayout::transform_vector`] or [`world_unit_vector`]
     pub fn unit_vector(self, orientation: HexOrientation) -> Vec2 {
         let angle = self.angle(orientation);
         Vec2::new(angle.cos(), angle.sin())
+    }
+
+    #[inline]
+    #[must_use]
+    /// Returns the unit vector of the direction in the given `layout`.
+    ///
+    /// The vector is provided in pixel/workd space. To use in local hex
+    /// space use [`unit_vector`]
+    pub fn world_unit_vector(self, layout: &HexLayout) -> Vec2 {
+        let vector = self.unit_vector(layout.orientation);
+        layout.transform_vector(vector)
     }
 
     #[inline]

--- a/src/direction/vertex_direction.rs
+++ b/src/direction/vertex_direction.rs
@@ -386,6 +386,9 @@ impl VertexDirection {
     #[inline]
     #[must_use]
     /// Returns the unit vector of the direction in the given `orientation`
+    ///
+    /// The vector is normalized and in local hex space. To use within a
+    /// [`HexLayout`] use [`HexLayout::transform_vector`]
     pub fn unit_vector(self, orientation: HexOrientation) -> Vec2 {
         let angle = self.angle(orientation);
         Vec2::new(angle.cos(), angle.sin())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@
 //!
 //! // Define your layout
 //! let layout = HexLayout {
-//!     hex_size: Vec2::new(1.0, 1.0),
+//!     scale: Vec2::new(1.0, 1.0),
 //!     orientation: HexOrientation::Flat,
 //!     ..Default::default()
 //! };

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -1,5 +1,4 @@
 use std::ops::Deref;
-
 pub(crate) const SQRT_3: f32 = 1.732_050_8;
 
 /// Pointy orientation matrices and offset


### PR DESCRIPTION
Reworked `HexLayout` axis scale management:

* (**BREAKING**) `HexLayout` removed the `invert_x` and `invert_y` fields
* (**BREAKING**) `HexLayout` `hex_size` field is now `scale`
* Added the following `HexLayout` methods: 
  - `transform_point`
  - `transform_vector`
  - `inverse_transform_point`
  - `inverse_transform_vector`
  - `invert_x`
  - `invert_y`
* Added `world_unit_vector` methods to `EdgeDirection` and `VertexDirection`