### PR TITLE
RectMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 * Rust 2024 edition (#225)
 * Added `HexBounds::corners` method (#223)
+* Added feature `bevy_ecs` (`dep:bevy_ecs`)
+  - which allow data types to derive `Component` and `Resource`.
+
+### `RectMap<T>`
+* Added `src/storage/rect.rs`
+  - `RectMap`, rectangular layout hex map
+    - internally use offset coordinate to map indice to 1D vec index
+    - implement `HexStore`
+  - `RectMetadata`, meta for `RectMap`, also act as builder pattern
+  - `WrapStrategy`, the wrapping strategy 
+    - `Clamp`, clamp to `min..max`, use for latitude
+    - `Cycle`, cycle the index, use for longitude
+  - tested for
+    - index conversion
+    - containment, and 
+    - wrapping indexing.
+* Added `examples/rect_map.rs` to demostrate `RectMap` usage
+
 
 ## 0.21.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,13 @@ packed = []
 # serde compatibility
 serde = ["dep:serde", "glam/serde"]
 # Adds support for the Bevy game engine
-bevy = ["bevy_reflect", "bevy_platform"]
+bevy = ["bevy_reflect", "bevy_platform", "bevy_ecs"]
 # Adds Bevy Reflection support
 bevy_reflect = ["dep:bevy_reflect"]
 # Adds Bevy Platform support
 bevy_platform = ["dep:bevy_platform"]
+# Adds Bevy ECS support
+bevy_ecs = ["dep:bevy_ecs"]
 
 [dependencies]
 glam = "0.29"
@@ -52,6 +54,10 @@ optional = true
 version = "0.16"
 optional = true
 
+[dependencies.bevy_ecs]
+version = "0.16"
+optional = true
+
 # For lib.rs doctests and examples
 [dev-dependencies.bevy]
 version = "0.16"
@@ -67,6 +73,7 @@ features = [
     "bevy_text",
     "bevy_window",
     "bevy_winit",
+    "bevy_ui",
     "default_font",
     "multi_threaded",
     "png",
@@ -134,6 +141,11 @@ required-features = ["bevy_platform"]
 name = "3d_picking"
 path = "examples/3d_picking.rs"
 required-features = ["bevy_platform"]
+
+[[example]]
+name = "rect_map"
+path = "examples/rect_map.rs"
+required-features = ["bevy_platform", "bevy_ecs"]
 
 [[example]]
 name = "mesh_builder"

--- a/examples/rect_map.rs
+++ b/examples/rect_map.rs
@@ -1,0 +1,275 @@
+use bevy::color::palettes::css::*;
+use bevy::math::VectorSpace;
+use bevy::platform::collections::HashMap;
+use bevy::prelude::*;
+use bevy::window::PrimaryWindow;
+
+use hexx::storage::{HexStore, RectMap, RectMetadata, WrapStrategy};
+use hexx::*;
+
+pub fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                resolution: (1_000.0, 1_000.0).into(),
+                ..default()
+            }),
+            ..default()
+        }))
+        .insert_resource(
+            RectMetadata::default()
+                .with_hex_layout(
+                    HexLayout::pointy()
+                        .with_hex_size(30.0)
+                        .with_origin(Vec2::ZERO),
+                )
+                .with_half_size(IVec2 { x: 8, y: 4 })
+                .with_wrap_strategies([WrapStrategy::Cycle, WrapStrategy::Clamp]),
+        )
+        .init_resource::<CursorHex>()
+        .add_event::<RespawnMap>()
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            (handle_input, respawn_map, cursor_draw, cursor_mat).chain(),
+        )
+        .run();
+}
+
+#[derive(Resource)]
+pub struct DefaultMaterial(pub MeshMaterial2d<ColorMaterial>);
+#[derive(Resource)]
+pub struct SelectedMaterial(pub MeshMaterial2d<ColorMaterial>);
+
+#[derive(Resource, Default)]
+pub struct CursorHex(pub Option<Hex>);
+
+#[derive(Component)]
+pub struct TextInstruction;
+
+#[derive(Event)]
+pub struct RespawnMap;
+
+/// setup
+fn setup(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut wtr: EventWriter<RespawnMap>,
+) {
+    commands.spawn(Camera2d);
+    let default_mat = MeshMaterial2d(materials.add(ColorMaterial::from_color(GRAY)));
+    commands.insert_resource(DefaultMaterial(default_mat));
+    let select_mat = MeshMaterial2d(materials.add(ColorMaterial::from_color(GREEN)));
+    commands.insert_resource(SelectedMaterial(select_mat));
+    commands.spawn((
+        Text::new(""),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(5.0),
+            left: Val::Px(5.0),
+            ..default()
+        },
+        TextInstruction,
+    ));
+
+    wtr.send(RespawnMap);
+}
+
+fn respawn_map(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut meta: Res<RectMetadata>,
+    default_mat: Res<DefaultMaterial>,
+    mut query: Query<Entity, With<Hex>>,
+    mut rdr: EventReader<RespawnMap>,
+    mut text: Query<&mut Text, With<TextInstruction>>,
+) {
+    if rdr.read().count() == 0 {
+        return;
+    }
+
+    let hex_size = 0.5 * meta.rect_size().max_element();
+    let wrap_strategies = meta.wrap_strategies();
+
+    let instructions = vec![
+        format!("hex size : {}", hex_size),
+        format!("half size: {:?}", meta.half_size()),
+        format!("Press <1> to change orientation: {:?}", meta.orientation),
+        format!("Press <2> to increase hex size"),
+        format!("Press <3> to decrease hex size"),
+        format!("Press <4> to increase column count"),
+        format!("Press <5> to decrease column count"),
+        format!("Press <6> to increase row count"),
+        format!("Press <7> to decrease column count"),
+        format!(
+            "Press <8> to change longitude wrapping strategy: {:?}",
+            wrap_strategies[0]
+        ),
+        format!(
+            "Press <9> to change latitude wrapping strategy: {:?}",
+            wrap_strategies[1]
+        ),
+    ]
+    .join("\n");
+
+    *text.single_mut().unwrap() = Text::new(instructions);
+
+    for i in query.iter() {
+        commands.entity(i).despawn();
+    }
+
+    let default_mesh = Mesh2d(meshes.add(RegularPolygon::new(0.9 * hex_size, 6)));
+
+    let angle = if meta.orientation == HexOrientation::Pointy {
+        0.0
+    } else {
+        30_f32.to_radians()
+    };
+
+    let map = meta.clone().build(|hex| {
+        let mut pos = meta.hex_to_world_pos(hex).xyy();
+        pos[2] = 0.0;
+
+        commands
+            .spawn((
+                hex,
+                Transform {
+                    translation: pos,
+                    rotation: Quat::from_rotation_z(angle),
+                    ..Default::default()
+                },
+                default_mat.0.clone(),
+                default_mesh.clone(),
+            ))
+            .id()
+    });
+
+    commands.insert_resource(map);
+}
+
+fn cursor_mat(
+    mut query: Query<(&mut MeshMaterial2d<ColorMaterial>, &Hex)>,
+    default_mat: Res<DefaultMaterial>,
+    select_mat: Res<SelectedMaterial>,
+    mut cursor_hex: Res<CursorHex>,
+) {
+    for (mut mat, h) in query.iter_mut() {
+        if cursor_hex.0 == Some(*h) {
+            *mat = select_mat.0.clone();
+        } else {
+            *mat = default_mat.0.clone();
+        }
+    }
+}
+
+fn handle_input(
+    key: Res<ButtonInput<KeyCode>>,
+    mut meta: ResMut<RectMetadata>,
+    mut wtr: EventWriter<RespawnMap>,
+) {
+    let mut changed = false;
+    let mut orientation = meta.orientation;
+    let mut hex_size = 0.5 * meta.rect_size().max_element();
+    let mut half_size: IVec2 = meta.half_size();
+    let mut wrap_strategies: [WrapStrategy; 2] = meta.wrap_strategies();
+
+    if key.just_pressed(KeyCode::Digit1) {
+        if orientation == HexOrientation::Flat {
+            orientation = HexOrientation::Pointy
+        } else {
+            orientation = HexOrientation::Flat
+        }
+        changed = true;
+    }
+    if key.just_pressed(KeyCode::Digit2) {
+        hex_size = (hex_size + 1.0).clamp(15.0, 45.0);
+        changed = true;
+    }
+    if key.just_pressed(KeyCode::Digit3) {
+        hex_size = (hex_size - 1.0).clamp(15.0, 45.0);
+        changed = true;
+    }
+    if key.just_pressed(KeyCode::Digit4) {
+        half_size[0] = (half_size[0] + 1).clamp(4, 16);
+        changed = true;
+    }
+    if key.just_pressed(KeyCode::Digit5) {
+        half_size[0] = (half_size[0] - 1).clamp(4, 16);
+        changed = true;
+    }
+    if key.just_pressed(KeyCode::Digit6) {
+        half_size[1] = (half_size[1] + 1).clamp(2, 8);
+        changed = true;
+    }
+    if key.just_pressed(KeyCode::Digit7) {
+        half_size[1] = (half_size[1] - 1).clamp(2, 8);
+        changed = true;
+    }
+    if key.just_pressed(KeyCode::Digit8) {
+        if wrap_strategies[0] == WrapStrategy::Clamp {
+            wrap_strategies[0] = WrapStrategy::Cycle;
+        } else {
+            wrap_strategies[0] = WrapStrategy::Clamp;
+        }
+        changed = true;
+    }
+    if key.just_pressed(KeyCode::Digit9) {
+        if wrap_strategies[1] == WrapStrategy::Clamp {
+            wrap_strategies[1] = WrapStrategy::Cycle;
+        } else {
+            wrap_strategies[1] = WrapStrategy::Clamp;
+        }
+        changed = true;
+    }
+
+    if changed {
+        let layout = if orientation == HexOrientation::Flat {
+            HexLayout::flat()
+        } else {
+            HexLayout::pointy()
+        }
+        .with_hex_size(hex_size);
+
+        *meta = RectMetadata::default()
+            .with_hex_layout(layout)
+            .with_half_size(half_size)
+            .with_wrap_strategies(wrap_strategies);
+
+        wtr.send(RespawnMap);
+    }
+}
+
+/// Input interaction
+fn cursor_draw(
+    mut commands: Commands,
+    mut gizmos: Gizmos,
+    windows: Query<&Window, With<PrimaryWindow>>,
+    cameras: Query<(&Camera, &GlobalTransform)>,
+    mut cursor_hex: ResMut<CursorHex>,
+    map: Res<RectMap<Entity>>,
+) -> Result {
+    *cursor_hex = CursorHex(None);
+    let window = windows.single()?;
+    let (camera, cam_transform) = cameras.single()?;
+    if let Some(pos) = window
+        .cursor_position()
+        .and_then(|p| camera.viewport_to_world_2d(cam_transform, p).ok())
+    {
+        // draw small red circle in cursor position
+        gizmos.circle_2d(Isometry2d::from_translation(pos), 5.0, RED);
+
+        let hex = map.world_pos_to_hex(pos);
+        let pos = map.hex_to_world_pos(hex);
+
+        // draw large red circle in snapped to current hex's center.
+        gizmos.circle_2d(
+            Isometry2d::from_translation(pos),
+            0.9 * 0.5 * map.rect_size().max_element(),
+            RED,
+        );
+
+        let wrapped_hex = map.wrap_hex(hex);
+        *cursor_hex = CursorHex(Some(wrapped_hex));
+    }
+    Ok(())
+}

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -20,6 +20,7 @@ pub enum DoubledHexMode {
 /// [offset]: https://www.redblobgames.com/grids/hexagons/#coordinates-offset
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub enum OffsetHexMode {
     /// Depending on the orientation:
     ///

--- a/src/hex/mod.rs
+++ b/src/hex/mod.rs
@@ -59,6 +59,10 @@ use std::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "packed", repr(C))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+#[cfg_attr(
+    feature = "bevy_ecs",
+    derive(bevy_ecs::resource::Resource, bevy_ecs::component::Component)
+)]
 pub struct Hex {
     /// `x` axial coordinate (sometimes called `q` or `i`)
     pub x: i32,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8,10 +8,12 @@
 //! [this article]: https://www.redblobgames.com/grids/hexagons/#map-storage
 pub(crate) mod hexagonal;
 pub(crate) mod hexmod;
+pub(crate) mod rect;
 pub(crate) mod rombus;
 
 pub use hexagonal::HexagonalMap;
 pub use hexmod::HexModMap;
+pub use rect::{RectMap, RectMetadata, WrapStrategy};
 pub use rombus::RombusMap;
 
 macro_rules! storage_impl {
@@ -49,6 +51,7 @@ macro_rules! storage_impl {
 storage_impl!(HexagonalMap<T>);
 storage_impl!(RombusMap<T>);
 storage_impl!(HexModMap<T>);
+storage_impl!(RectMap<T>);
 
 /// Trait grouping common features for hexagonal storage types.
 ///

--- a/src/storage/rect.rs
+++ b/src/storage/rect.rs
@@ -82,7 +82,7 @@ pub struct RectMetadata {
     /// the hex layout of the map
     hex_layout: HexLayout,
     /// the offset mode of the map
-    /// 
+    ///
     /// affect which way does the map zic zac.
     offset_mode: OffsetHexMode,
     /// the half size of the map
@@ -267,8 +267,8 @@ impl RectMetadata {
     /// - => `rc` 2D view of `Vec`
     /// - => `idx` `Vec` index
     fn ij_to_idx(&self, ij: IVec2) -> usize {
-        let rc = ij + self.half_size;
-        (rc[0] + rc[1] * (2 * self.half_size[0])) as usize
+        let rc = (ij + self.half_size).as_uvec2();
+        (rc[0] + rc[1] * (2 * self.half_size.as_uvec2()[0])) as usize
     }
 
     /// infallable
@@ -325,7 +325,7 @@ impl RectMetadata {
     /// total size of the map
     #[must_use]
     pub fn len(&self) -> usize {
-        self.half_size.element_product() as usize * 4
+        (self.half_size.as_uvec2().element_product() * 4) as usize
     }
 
     /// whether of not the map layout is empty
@@ -376,7 +376,7 @@ impl<T> RectMap<T> {
     #[must_use]
     #[allow(clippy::cast_possible_wrap)]
     pub fn new(meta: RectMetadata, mut values: impl FnMut(Hex) -> T) -> Self {
-        let size = meta.half_size.element_product() as usize * 4;
+        let size = (meta.half_size.as_uvec2().element_product() * 4) as usize;
         let mut inner = Vec::with_capacity(size);
         for h in meta.iter_hex() {
             inner.push(values(h));

--- a/src/storage/rect.rs
+++ b/src/storage/rect.rs
@@ -1,0 +1,619 @@
+use std::fmt::Debug;
+
+use glam::{IVec2, Vec2Swizzles};
+
+use crate::{Hex, HexLayout, OffsetHexMode, storage::HexStore};
+
+/// [`Vec`] Based storage for rectangular maps.
+///
+/// > See [this article](https://www.redblobgames.com/grids/hexagons/#map-storage)
+///
+/// [`RectMap`] is made for _rectangular_ large _dense_ maps, utilizing some
+/// tricks to map [`Hex`] coordinate to a positive 1D array.
+///
+/// It can be used only if:
+/// - The map is a rectanglar shape
+/// - The map is _dense_
+/// - No coordinate will be added or removed from the map
+///
+/// If your use case doesn't match all of the above, use a [`std::collections::HashMap`] instead
+///
+/// # Example
+/// ```rust
+/// use hexx::storage::{HexStore, RectMap, RectMetadata, WrapStrategy};
+/// use hexx::*;
+///
+/// let layout = HexLayout::pointy()
+///     .with_hex_size(30.0)
+///     .with_origin(Vec2::ZERO);
+/// let rect_map = RectMetadata::default()
+///     .with_hex_layout(layout)
+///     .with_half_size(IVec2 { x: 8, y: 4 })
+///     .with_wrap_strategies([WrapStrategy::Cycle, WrapStrategy::Clamp])
+///     .build_default::<i32>();
+///
+/// assert_eq!(rect_map.get(Hex::new(0, 0)), Some(&0));
+/// ```
+///
+/// internally handle coordinate transform
+/// - `hex`
+/// - => `ij` offset coordinate
+/// - => `rc` 2D view of `Vec`
+/// - => `idx` `Vec` index
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+#[cfg_attr(
+    feature = "bevy_ecs",
+    derive(bevy_ecs::resource::Resource, bevy_ecs::component::Component)
+)]
+#[derive(Clone)]
+pub struct RectMap<T> {
+    inner: Vec<T>,
+    meta: RectMetadata,
+}
+
+/// Metadata struct for [`RectMap`]
+///
+/// # Example
+/// ```rust
+/// use hexx::{Hex, HexLayout, OffsetHexMode};
+/// use hexx::storage::{RectMap, HexStore, RectMetadata, WrapStrategy};
+/// use hexx::IVec2;
+///
+/// let rect_hex_map = RectMetadata::default()
+///     .with_hex_layout(HexLayout::pointy().with_hex_size(1.0))
+///     .with_half_size(IVec2::new(8,12))
+///     .with_offset_mode(OffsetHexMode::Odd)
+///     .with_wrap_strategies([WrapStrategy::Cycle, WrapStrategy::Clamp])
+///     .build_default::<i32>();
+/// let hex = Hex::new(0,0);
+///
+/// assert_eq!(rect_hex_map.get(hex), Some(&0_i32));
+/// assert_eq!(rect_hex_map.wrapped_get(hex), &0_i32);
+/// ```
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+#[cfg_attr(
+    feature = "bevy_ecs",
+    derive(bevy_ecs::resource::Resource, bevy_ecs::component::Component)
+)]
+pub struct RectMetadata {
+    /// the hex layout of the map
+    hex_layout: HexLayout,
+    /// the offset mode of the map
+    /// 
+    /// affect which way does the map zic zac.
+    offset_mode: OffsetHexMode,
+    /// the half size of the map
+    half_size: IVec2,
+    /// the wrapping strategy for indexing
+    wrap_strategies: [WrapStrategy; 2],
+}
+
+/// Wrapping Strategy for when try to [`RectMap::wrapped_get`] and [`RectMap::wrapped_get_mut`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub enum WrapStrategy {
+    /// Clamp (offset) coordinate to `min` and `max - 1`
+    ///
+    /// useful for latitude/vertical coordinate
+    Clamp,
+    /// Cycle (offset) coordinate to range of`min` and `max - 1`
+    ///
+    /// useful for longitude/horizontal coordinate
+    Cycle,
+}
+
+impl Default for RectMetadata {
+    fn default() -> Self {
+        Self {
+            hex_layout: HexLayout::pointy(),
+            offset_mode: OffsetHexMode::Odd,
+            half_size: IVec2::new(32, 16),
+            wrap_strategies: [WrapStrategy::Cycle, WrapStrategy::Clamp],
+        }
+    }
+}
+
+impl RectMetadata {
+    // ================================
+    // Builder Pattern
+    // ================================
+    /// builder patter, set hex layout
+    #[must_use]
+    pub const fn with_hex_layout(mut self, hex_layout: HexLayout) -> Self {
+        self.hex_layout = hex_layout;
+        self
+    }
+    /// builder patter, set half size
+    #[must_use]
+    pub fn with_half_size(mut self, half_size: IVec2) -> Self {
+        self.half_size = half_size.abs();
+        self
+    }
+    /// builder patter, set offset mode
+    #[must_use]
+    pub const fn with_offset_mode(mut self, offset_mode: OffsetHexMode) -> Self {
+        self.offset_mode = offset_mode;
+        self
+    }
+    /// builder patter, set wrapping strategy
+    #[must_use]
+    pub const fn with_wrap_strategies(mut self, wrap_strategies: [WrapStrategy; 2]) -> Self {
+        self.wrap_strategies = wrap_strategies;
+        self
+    }
+    /// builder patter, build map with function to eval value
+    /// # Example
+    /// ```rust
+    /// use hexx::storage::{HexStore, RectMap, RectMetadata, WrapStrategy};
+    /// use hexx::*;
+    ///
+    /// let layout = HexLayout::pointy()
+    ///     .with_hex_size(30.0)
+    ///     .with_origin(Vec2::ZERO);
+    /// let rect_map = RectMetadata::default()
+    ///     .with_hex_layout(layout)
+    ///     .with_half_size(IVec2 { x: 8, y: 4 })
+    ///     .with_wrap_strategies([WrapStrategy::Cycle, WrapStrategy::Clamp])
+    ///     .build(|hex| hex.x + hex.y);
+    ///
+    /// assert_eq!(rect_map.get(Hex::new(0, 0)), Some(&0));
+    /// ```
+    pub fn build<T>(self, values: impl FnMut(Hex) -> T) -> RectMap<T> {
+        RectMap::new(self, values)
+    }
+    /// builder patter, build map with default values
+    /// # Example
+    /// ```rust
+    /// use hexx::storage::{HexStore, RectMap, RectMetadata, WrapStrategy};
+    /// use hexx::*;
+    ///
+    /// let layout = HexLayout::pointy()
+    ///     .with_hex_size(30.0)
+    ///     .with_origin(Vec2::ZERO);
+    /// let rect_map = RectMetadata::default()
+    ///     .with_hex_layout(layout)
+    ///     .with_half_size(IVec2 { x: 8, y: 4 })
+    ///     .with_wrap_strategies([WrapStrategy::Cycle, WrapStrategy::Clamp])
+    ///     .build_default::<i32>();
+    ///
+    /// assert_eq!(rect_map.get(Hex::new(0, 0)), Some(&0));
+    /// ```
+    #[must_use]
+    pub fn build_default<T: Default>(self) -> RectMap<T> {
+        RectMap::default_values(self)
+    }
+
+    // ================================
+    // Access
+    // ================================
+    /// get the offset mode of the map
+    #[must_use]
+    pub const fn offset_mode(&self) -> OffsetHexMode {
+        self.offset_mode
+    }
+    /// get the half size of the map
+    #[must_use]
+    pub const fn half_size(&self) -> IVec2 {
+        self.half_size
+    }
+    /// get the wrap strategies of the map
+    #[must_use]
+    pub const fn wrap_strategies(&self) -> [WrapStrategy; 2] {
+        self.wrap_strategies
+    }
+
+    // ================================
+    // Forward Coordinate Conversion
+    // ================================
+    /// calculate hex coordinate from index
+    ///
+    /// infallible
+    ///
+    /// - `idx` `Vec` index  
+    /// - => `rc` 2D view of `Vec`
+    /// - => `ij` offset coordinate
+    /// - => `hex`
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    fn idx_to_hex(&self, idx: usize) -> Hex {
+        let idx = idx as i32;
+        let rc = IVec2::new(idx % (2 * self.half_size[0]), idx / (2 * self.half_size[0]));
+        let ij = rc - self.half_size;
+        self.ij_to_hex(ij)
+    }
+
+    fn ij_to_hex(&self, ij: IVec2) -> Hex {
+        Hex::from_offset_coordinates(
+            ij.xy().to_array(),
+            self.offset_mode,
+            self.hex_layout.orientation,
+        )
+    }
+
+    // ================================
+    // Backward Coordinate Conversion
+    // ================================
+    /// `None` if outside map
+    fn hex_to_idx(&self, hex: Hex) -> Option<usize> {
+        let ij = self.hex_to_ij(hex);
+        if self.contains_ij(ij) {
+            Some(self.ij_to_idx(ij))
+        } else {
+            None
+        }
+    }
+
+    /// Wrap if `hex` lie outside of layout
+    fn wrapped_hex_to_idx(&self, hex: Hex) -> usize {
+        let ij = self.hex_to_ij(hex);
+        let ij = self.wrap_ij(ij);
+        self.ij_to_idx(ij)
+    }
+
+    /// infallable
+    fn hex_to_ij(&self, hex: Hex) -> IVec2 {
+        let v: IVec2 = hex
+            .to_offset_coordinates(self.offset_mode, self.hex_layout.orientation)
+            .into();
+        v.xy()
+    }
+
+    /// fallable input, internal
+    ///
+    /// - `ij` offset coordinate
+    /// - => `rc` 2D view of `Vec`
+    /// - => `idx` `Vec` index
+    fn ij_to_idx(&self, ij: IVec2) -> usize {
+        let rc = ij + self.half_size;
+        (rc[0] + rc[1] * (2 * self.half_size[0])) as usize
+    }
+
+    /// infallable
+    fn wrap_ij(&self, mut ij: IVec2) -> IVec2 {
+        if self.wrap_strategies[0] == WrapStrategy::Cycle {
+            while ij[0] < -self.half_size[0] {
+                ij[0] += self.half_size[0] * 2;
+            }
+            while ij[0] >= self.half_size[0] {
+                ij[0] -= self.half_size[0] * 2;
+            }
+        } else {
+            ij[0] = ij[0].clamp(-self.half_size[0], self.half_size[0] - 1);
+        }
+
+        if self.wrap_strategies[1] == WrapStrategy::Cycle {
+            while ij[1] < -self.half_size[1] {
+                ij[1] += self.half_size[1] * 2;
+            }
+            while ij[1] >= self.half_size[1] {
+                ij[1] -= self.half_size[1] * 2;
+            }
+        } else {
+            ij[1] = ij[1].clamp(-self.half_size[1], self.half_size[1] - 1);
+        }
+
+        ij
+    }
+
+    /// Wrap a Hex to ensure it fall inside the map
+    #[must_use]
+    pub fn wrap_hex(&self, hex: Hex) -> Hex {
+        let ij = self.hex_to_ij(hex);
+        let ij = self.wrap_ij(ij);
+        self.ij_to_hex(ij)
+    }
+
+    // ================================
+    // Contains
+    // ================================
+    /// whether the map contains certain `Hex`
+    #[must_use]
+    pub fn contains_hex(&self, hex: Hex) -> bool {
+        self.contains_ij(self.hex_to_ij(hex))
+    }
+    /// internally
+    fn contains_ij(&self, ij: IVec2) -> bool {
+        ij == ij.clamp(-self.half_size, self.half_size.wrapping_sub([1, 1].into()))
+    }
+
+    // ================================
+    // Iteration
+    // ================================
+    /// total size of the map
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.half_size.element_product() as usize * 4
+    }
+
+    /// whether of not the map layout is empty
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// iterator over the hexagonal coordinates in the map.
+    pub fn iter_hex(&self) -> impl Iterator<Item = Hex> + use<'_> {
+        (0..self.len()).map(|idx| self.idx_to_hex(idx))
+    }
+}
+
+impl std::ops::Deref for RectMetadata {
+    type Target = HexLayout;
+    fn deref(&self) -> &Self::Target {
+        &self.hex_layout
+    }
+}
+
+impl<T> RectMap<T> {
+    // ================================
+    // Creation
+    // ================================
+    /// Creates and fills a rectangular shaped map
+    ///
+    /// # Arguments
+    /// * `meta`: The meta data for the map to create.
+    /// * `values` - Function called for each coordinate to fill the map
+    ///
+    /// # Example
+    /// ```
+    /// use hexx::storage::{HexStore, RectMap, RectMetadata, WrapStrategy};
+    /// use hexx::*;
+    ///
+    /// let layout = HexLayout::pointy()
+    ///     .with_hex_size(30.0)
+    ///     .with_origin(Vec2::ZERO);
+    /// let meta = RectMetadata::default()
+    ///     .with_hex_layout(layout)
+    ///     .with_half_size(IVec2 { x: 8, y: 4 })
+    ///     .with_wrap_strategies([WrapStrategy::Cycle, WrapStrategy::Clamp]);
+    /// let rect_map = RectMap::new(meta, |hex| hex.x + hex.y);
+    ///
+    /// assert_eq!(rect_map.get(Hex::new(0, 0)), Some(&0));
+    /// ```
+    #[must_use]
+    #[allow(clippy::cast_possible_wrap)]
+    pub fn new(meta: RectMetadata, mut values: impl FnMut(Hex) -> T) -> Self {
+        let size = meta.half_size.element_product() as usize * 4;
+        let mut inner = Vec::with_capacity(size);
+        for h in meta.iter_hex() {
+            inner.push(values(h));
+        }
+        Self { inner, meta }
+    }
+
+    /// Creates and fills a rectangular shaped map
+    ///
+    /// # Arguments
+    /// * `meta`: The meta data for the map to create.
+    ///
+    /// # Example
+    /// ```
+    /// use hexx::storage::{HexStore, RectMap, RectMetadata, WrapStrategy};
+    /// use hexx::*;
+    ///
+    /// let layout = HexLayout::pointy()
+    ///     .with_hex_size(30.0)
+    ///     .with_origin(Vec2::ZERO);
+    /// let meta = RectMetadata::default()
+    ///     .with_hex_layout(layout)
+    ///     .with_half_size(IVec2 { x: 8, y: 4 })
+    ///     .with_wrap_strategies([WrapStrategy::Cycle, WrapStrategy::Clamp]);
+    /// let rect_map = RectMap::default_values(meta);
+    ///
+    /// assert_eq!(rect_map.get(Hex::new(0, 0)), Some(&0));
+    /// ```
+    #[must_use]
+    pub fn default_values(meta: RectMetadata) -> Self
+    where
+        T: Default,
+    {
+        Self::new(meta, |_| Default::default())
+    }
+
+    // ================================
+    // Wrapped Index
+    // ================================
+    /// Wrap if `hex` lie outside of layout
+    /// - Clamp for latitude/vertical coordinate
+    /// - Wrap for longitude/horizontal coordinate
+    #[must_use]
+    pub fn wrapped_get(&self, hex: Hex) -> &T {
+        let idx = self.meta.wrapped_hex_to_idx(hex);
+        &self.inner[idx]
+    }
+
+    /// Wrap if `hex` lie outside of layout
+    /// - Clamp for latitude/vertical coordinate
+    /// - Wrap for longitude/horizontal coordinate
+    pub fn wrapped_get_mut(&mut self, hex: Hex) -> &mut T {
+        let idx = self.meta.wrapped_hex_to_idx(hex);
+        &mut self.inner[idx]
+    }
+}
+
+impl<T> std::ops::Deref for RectMap<T> {
+    type Target = RectMetadata;
+    fn deref(&self) -> &Self::Target {
+        &self.meta
+    }
+}
+
+impl<T: Default> Default for RectMap<T> {
+    fn default() -> Self {
+        RectMetadata::default().build_default()
+    }
+}
+
+impl<T> HexStore<T> for RectMap<T> {
+    fn get(&self, hex: crate::Hex) -> Option<&T> {
+        let idx = self.meta.hex_to_idx(hex)?;
+        self.inner.get(idx)
+    }
+    fn get_mut(&mut self, hex: crate::Hex) -> Option<&mut T> {
+        let idx = self.meta.hex_to_idx(hex)?;
+        self.inner.get_mut(idx)
+    }
+    fn values<'s>(&'s self) -> impl ExactSizeIterator<Item = &'s T>
+    where
+        T: 's,
+    {
+        self.inner.iter()
+    }
+    fn values_mut<'s>(&'s mut self) -> impl ExactSizeIterator<Item = &'s mut T>
+    where
+        T: 's,
+    {
+        self.inner.iter_mut()
+    }
+    fn iter<'s>(&'s self) -> impl ExactSizeIterator<Item = (crate::Hex, &'s T)>
+    where
+        T: 's,
+    {
+        self.values().enumerate().map(|(i, value)| {
+            let hex = self.meta.idx_to_hex(i);
+            (hex, value)
+        })
+    }
+    fn iter_mut<'s>(&'s mut self) -> impl ExactSizeIterator<Item = (crate::Hex, &'s mut T)>
+    where
+        T: 's,
+    {
+        let meta = self.meta.clone();
+        self.values_mut().enumerate().map(move |(i, value)| {
+            let hex = meta.idx_to_hex(i);
+            (hex, value)
+        })
+    }
+}
+
+impl<T: Debug> Debug for RectMap<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RectMap")
+            .field("inner", &self.inner)
+            .field("meta", &self.meta)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Test dimensions for creating RectHexMap instances.
+    const HALF_SIZES: &[[i32; 2]] = &[
+        [0, 0],
+        [0, 1],
+        [1, 1],
+        [2, 2],
+        [8, 4],
+        [16, 8],
+        [28, 8],
+        [64, 128],
+        [127, 201],
+        [256, 512],
+        [-40, 3],
+    ];
+
+    const WRAP_STRATEGIES: &[[WrapStrategy; 2]] = &[
+        [WrapStrategy::Clamp, WrapStrategy::Clamp],
+        [WrapStrategy::Clamp, WrapStrategy::Cycle],
+        [WrapStrategy::Cycle, WrapStrategy::Clamp],
+        [WrapStrategy::Cycle, WrapStrategy::Cycle],
+    ];
+
+    /// Tests the conversion between index and hexagonal coordinates.
+    #[test]
+    fn idx_hex_test() {
+        for dim in HALF_SIZES {
+            let rect_hex_map = RectMetadata::default()
+                .with_hex_layout(HexLayout::pointy().with_hex_size(1.0))
+                .with_half_size(IVec2::from_array(*dim))
+                .with_offset_mode(OffsetHexMode::Odd)
+                .with_wrap_strategies([WrapStrategy::Cycle, WrapStrategy::Clamp])
+                .build_default::<i32>();
+
+            for idx in 0..rect_hex_map.len() {
+                let hex = rect_hex_map.idx_to_hex(idx);
+                assert!(rect_hex_map.contains_hex(hex));
+                let _idx = rect_hex_map.hex_to_idx(hex);
+                assert_eq!(Some(idx), _idx);
+            }
+        }
+    }
+
+    /// Tests the containment of ij coordinates within the map.
+    #[test]
+    fn contains_test() {
+        for dim in HALF_SIZES {
+            let rect_hex_map = RectMetadata::default()
+                .with_hex_layout(HexLayout::pointy().with_hex_size(1.0))
+                .with_offset_mode(OffsetHexMode::Odd)
+                .with_half_size(IVec2::from_array(*dim))
+                .with_wrap_strategies([WrapStrategy::Cycle, WrapStrategy::Clamp])
+                .build_default::<i32>();
+
+            for a in -2..2 {
+                for b in -2..2 {
+                    for i in (2 * a * dim[0])..((2 * a + 1) * dim[0]) {
+                        for j in (2 * b * dim[1])..((2 * b + 1) * dim[1]) {
+                            assert_eq!(
+                                a == 0 && b == 0,
+                                rect_hex_map.contains_ij(IVec2::new(i, j))
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Tests the wrapping functionality of ij coordinates.
+    #[test]
+    fn wrap_test() {
+        for dim in HALF_SIZES {
+            for wrap_strategies in WRAP_STRATEGIES {
+                let rect_hex_map = RectMetadata::default()
+                    .with_hex_layout(HexLayout::pointy().with_hex_size(1.0))
+                    .with_offset_mode(OffsetHexMode::Odd)
+                    .with_half_size(IVec2::from_array(*dim))
+                    .with_wrap_strategies(*wrap_strategies)
+                    .build_default::<i32>();
+
+                for a in -2..2 {
+                    for b in -2..2 {
+                        let i_iter_a = (2 * a * dim[0] - dim[0])..((2 * a) * dim[0] + dim[0]);
+                        let i_iter_b: Box<dyn Iterator<Item = i32>> =
+                            if wrap_strategies[0] == WrapStrategy::Cycle {
+                                Box::new(-dim[0]..dim[0])
+                            } else {
+                                Box::new(i_iter_a.clone().map(|i| i.clamp(-dim[0], dim[0] - 1)))
+                            };
+
+                        for (ia, ib) in i_iter_a.zip(i_iter_b) {
+                            let j_iter_a = (2 * b * dim[1] - dim[1])..((2 * b) * dim[1] + dim[1]);
+                            let j_iter_b: Box<dyn Iterator<Item = i32>> =
+                                if wrap_strategies[1] == WrapStrategy::Cycle {
+                                    Box::new(-dim[1]..dim[1])
+                                } else {
+                                    Box::new(j_iter_a.clone().map(|j| j.clamp(-dim[1], dim[1] - 1)))
+                                };
+
+                            for (ja, jb) in j_iter_a.zip(j_iter_b) {
+                                let ij_a = IVec2::new(ia, ja);
+                                let ij_b = IVec2::new(ib, jb);
+
+                                let wij_a = rect_hex_map.wrap_ij(ij_a);
+                                let wij_b = rect_hex_map.wrap_ij(ij_b);
+
+                                assert_eq!(wij_a, wij_b);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Development Workflow
- [x] `cargo clippy`
- [x] `cargo build`
- [x] `cargo fmt`
- [x] `cargo rustdoc`
- [x] `cargo test`

# Added
## `examples/rect_map.rs`
An example of using `RectMap`.

```bash
cargo run --example rect_map --features "bevy"
```

<img width="1249" height="1072" alt="image" src="https://github.com/user-attachments/assets/e1f100ab-b612-43c5-9022-f4c1f278b254" />


## `src/storage/rect.rs`
- [x] unit test

A hex storage map that internally use an 1D Vec, and index by converting to offset coordinate.
```rust
pub struct RectMap<T> {
    inner: Vec<T>,
    meta: RectMetadata,
}
```

The meta data for `RectMap`, but also act as the builder.
```rust
pub struct RectMetadata {
    hex_layout: HexLayout,
    offset_mode: OffsetHexMode,
    half_size: IVec2,
    wrap_strategies: [WrapStrategy; 2],
}
```

Wrapping Strategy when trying to wrap hex coordinate to ensure it contain inside the map.
```rust
pub enum WrapStrategy {
    Clamp,
    Cycle,
}
```

### Example 
```rust
let rect_hex_map = RectMetadata::default()
    .with_hex_layout(HexLayout::pointy().with_hex_size(1.0))
    .with_half_size(IVec2::new(8,12))
    .with_offset_mode(OffsetHexMode::Odd)
    .with_wrap_strategies([WrapStrategy::Cycle, WrapStrategy::Clamp])
    .build_default::<i32>();
```

## feature `bevy_ecs`
Added feature to derive `Resource` and `Component` for `hexx`'s types.

```rust
#[cfg_attr(
    feature = "bevy_ecs",
    derive(bevy_ecs::resource::Resource, bevy_ecs::component::Component)
)]
#[derive(Clone)]
pub struct RectMap<T> {
    /* ... */
}
```